### PR TITLE
Revert "Change submodules url to relative-path for greater 'clone' flexibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bazil"]
 	path = bazil
-	url = ../fuse
+	url = git@github.com:nestybox/fuse


### PR DESCRIPTION
This reverts commit ffe566d3ae6911f97a40d68140bbb1816c8e21a1.

Unfortunately, even though recursive git-clone operation works as expected with submodule's relative-path, Github portal is not properly handling this feature and, thereby, submodules are not reachable through Github's UI.

This Github issue is being tracked here: https://github.community/t/support-linking-relative-urls-on-submodules/2078

Signed-off-by: Rodny Molina <rmolina@nestybox.com>