### PR TITLE
Extend sysbox-fs to support overlayfs mounts on unprivileged user-ns

### DIFF
--- a/cmd/sysbox-fs/main.go
+++ b/cmd/sysbox-fs/main.go
@@ -292,6 +292,8 @@ func main() {
 		// Setup sysbox-fs services.
 		processService.Setup(ioService)
 
+		nsenterService.Setup(processService)
+
 		handlerService.Setup(
 			handler.DefaultHandlers,
 			ctx.Bool("ignore-handler-errors"),

--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -95,6 +95,7 @@ type NSenterServiceIface interface {
 		req *NSenterMessage,
 		res *NSenterMessage) NSenterEventIface
 
+	Setup(prs ProcessServiceIface)
 	SendRequestEvent(e NSenterEventIface) error
 	ReceiveResponseEvent(e NSenterEventIface) *NSenterMessage
 }
@@ -131,11 +132,15 @@ type NSenterMessage struct {
 }
 
 type NSenterMsgHeader struct {
-	Pid            uint32 `json:"pid"`
-	Uid            uint32 `json:"uid"`
-	Gid            uint32 `json:"gid"`
-	CapDacRead     bool   `json:"capDacRead"`
-	CapDacOverride bool   `json:"capDacOverride"`
+	Pid          uint32    `json:"pid"`
+	Uid          uint32    `json:"uid"`
+	Gid          uint32    `json:"gid"`
+	Root         string    `json:"root"`
+	Cwd          string    `json:"cwd"`
+	Capabilities [2]uint32 `json:"capabilities"`
+	// CapSysAdmin    bool     `json:"capAdmin"`
+	// CapDacRead     bool     `json:"capDacRead"`
+	// CapDacOverride bool     `json:"capDacOverride"`
 }
 
 type LookupPayload struct {
@@ -163,15 +168,32 @@ type ReadDirPayload struct {
 }
 
 type MountSyscallPayload struct {
+	Header NSenterMsgHeader
 	Source string `json:"source"`
 	Target string `json:"target"`
 	FsType string `json:"fstype"`
 	Flags  uint64 `json:"flags"`
 	Data   string `json:"data"`
+	FsBlob OverlayfsBlob
 }
 
 type UmountSyscallPayload struct {
+	Header NSenterMsgHeader
 	Target string `json:"target"`
 	FsType uint8  `json:"-"`
 	Flags  uint64 `json:"flags"`
+}
+
+type OverlayfsBlob struct {
+	LowerDir string `json:"-"`
+	UpperDir string `json:"-"`
+	WorkDir  string `json:"workdir"`
+	MergeDir string `json:"-"`
+}
+
+type MknodSyscallPayload struct {
+	Header NSenterMsgHeader
+	Path   string `json:"path"`
+	Mode   uint32 `json:"uint32"`
+	Dev    uint64 `json:"uint64"`
 }

--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -138,9 +138,6 @@ type NSenterMsgHeader struct {
 	Root         string    `json:"root"`
 	Cwd          string    `json:"cwd"`
 	Capabilities [2]uint32 `json:"capabilities"`
-	// CapSysAdmin    bool     `json:"capAdmin"`
-	// CapDacRead     bool     `json:"capDacRead"`
-	// CapDacOverride bool     `json:"capDacOverride"`
 }
 
 type LookupPayload struct {
@@ -174,7 +171,6 @@ type MountSyscallPayload struct {
 	FsType string `json:"fstype"`
 	Flags  uint64 `json:"flags"`
 	Data   string `json:"data"`
-	FsBlob OverlayfsBlob
 }
 
 type UmountSyscallPayload struct {
@@ -182,18 +178,4 @@ type UmountSyscallPayload struct {
 	Target string `json:"target"`
 	FsType uint8  `json:"-"`
 	Flags  uint64 `json:"flags"`
-}
-
-type OverlayfsBlob struct {
-	LowerDir string `json:"-"`
-	UpperDir string `json:"-"`
-	WorkDir  string `json:"workdir"`
-	MergeDir string `json:"-"`
-}
-
-type MknodSyscallPayload struct {
-	Header NSenterMsgHeader
-	Path   string `json:"path"`
-	Mode   uint32 `json:"uint32"`
-	Dev    uint64 `json:"uint64"`
 }

--- a/domain/process.go
+++ b/domain/process.go
@@ -36,12 +36,22 @@ type ProcessIface interface {
 	Pid() uint32
 	Uid() uint32
 	Gid() uint32
-	IsAdminCapabilitySet() bool
+	Cwd() string
+	Root() string
+	IsSysAdminCapabilitySet() bool
 	NsInodes() (map[string]Inode, error)
 	UserNsInode() (Inode, error)
 	UserNsInodeParent() (Inode, error)
 	CreateNsInodes(Inode) error
 	PathAccess(path string, accessFlags AccessMode) error
+	GetEffCaps() [2]uint32
+	SetEffCaps(caps [2]uint32)
+	Camouflage(
+		uid uint32,
+		gid uint32,
+		root string,
+		cwd string,
+		caps [2]uint32) error
 }
 
 type ProcessServiceIface interface {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/vishvananda/netlink v1.0.0
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
 	google.golang.org/grpc v1.27.0
+	gopkg.in/hlandau/service.v1 v1.0.7
 )
 
 replace github.com/nestybox/sysbox-ipc => ../sysbox-ipc

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ google.golang.org/protobuf v1.22.0 h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2M
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/hlandau/service.v1 v1.0.7 h1:16G5AJ1Cp8Vr65QItJXpyAIzf/FWAWCZBsTgsc6eyA8=
+gopkg.in/hlandau/service.v1 v1.0.7/go.mod h1:sZw6ksxcoafC04GoZtw32UeqqEuPSABX35lVBaJP/bE=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -620,6 +620,10 @@ func (e *NSenterEvent) processMountSyscallRequest() error {
 
 	payload := e.ReqMsg.Payload.([]domain.MountSyscallPayload)
 
+	// For overlayfs mounts we adjust 'nsexec' process' personality (i.e.
+	// uid/gid and capabilities) to match the one of the original process
+	// performing the syscall. Our goal is mainly to avoid permission issues
+	// while accessing kernel's created overlayfs components.
 	if payload[0].FsType == "overlay" {
 		// Create a 'process' struct to represent the 'sysbox-fs nsenter' process
 		// executing this logic.

--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -625,7 +625,8 @@ func (e *NSenterEvent) processMountSyscallRequest() error {
 		// executing this logic.
 		process := e.service.prs.ProcessCreate(0, 0, 0)
 
-		// Extract payload-header from the first element of the payload slice.
+		// Extract payload-header from the first element (just one in overlayfs
+		// mounts) of the payload slice .
 		header := payload[0].Header
 
 		// Adjust 'nsenter' process personality to match the end-user's original

--- a/nsenter/eventService.go
+++ b/nsenter/eventService.go
@@ -21,6 +21,7 @@ import (
 )
 
 type nsenterService struct {
+	prs    domain.ProcessServiceIface // for process class interactions (capabilities)
 	reaper *zombieReaper
 }
 
@@ -28,6 +29,11 @@ func NewNSenterService() domain.NSenterServiceIface {
 	return &nsenterService{
 		reaper: newZombieReaper(),
 	}
+}
+
+func (s *nsenterService) Setup(prs domain.ProcessServiceIface) {
+
+	s.prs = prs
 }
 
 func (s *nsenterService) NewEvent(

--- a/seccomp/mount.go
+++ b/seccomp/mount.go
@@ -437,8 +437,6 @@ func (m *mountSyscallInfo) createOverlayMountPayload(
 		Capabilities: process.GetEffCaps(),
 	}
 
-	payload[0].FsBlob = m.FsBlob
-
 	return &payload
 }
 

--- a/seccomp/syscall.go
+++ b/seccomp/syscall.go
@@ -25,6 +25,10 @@ type syscallCtx struct {
 	syscallNum int32                 // Value representing the syscall
 	reqId      uint64                // Id associated to the syscall request
 	pid        uint32                // Pid of the process generating the syscall
+	uid        uint32                // Uid of the process generating the syscall
+	gid        uint32                // Gid of the process generating the syscall
+	cwd        string                // Cwd of process generating the syscall
+	root       string                // Root of process generating the syscall
 	cntr       domain.ContainerIface // Container hosting the process generating the syscall
 	tracer     *syscallTracer        // Backpointer to the seccomp-tracer owning the syscall
 }

--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -92,9 +92,15 @@ func (u *umountSyscallInfo) process() (*sysResponse, error) {
 			// portions of procfs (e.g., proc/sys, proc/uptime, etc.)
 			logrus.Debugf("Processing procfs unmount: %v", u)
 			return u.processUmount(mip)
+
 		case "sysfs":
-			// For sysfs we do something similar to procfs
+			// For sysfs we do something similar to procfs.
 			logrus.Debugf("Processing sysfs unmount: %v", u)
+			return u.processUmount(mip)
+
+		case "overlay":
+			// Handle umounts of overlay fs.
+			logrus.Debugf("Processing overlayfs unmount: %v", u)
 			return u.processUmount(mip)
 		}
 

--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -184,8 +184,8 @@ func (u *umountSyscallInfo) createUmountPayload(
 	}
 
 	// Adjust payload attributes attending to the process' root path. This is
-	// needed to properly handle umount instructions generated within chroot'ed
-	// environments.
+	// needed to properly handle umount instructions generated within chroot
+	// jail environments.
 	if u.syscallCtx.root != "/" {
 		for i := 0; i < len(payload); i++ {
 			payload[i].Target = filepath.Join(u.syscallCtx.root, payload[i].Target)
@@ -196,5 +196,6 @@ func (u *umountSyscallInfo) createUmountPayload(
 }
 
 func (u *umountSyscallInfo) String() string {
-	return fmt.Sprintf("target = %s, flags = %#x", u.Target, u.Flags)
+	return fmt.Sprintf("target: %s, flags: %#x, root: %s, cwd: %s",
+		u.Target, u.Flags, u.root, u.cwd)
 }


### PR DESCRIPTION
This one is a key requirement to support Sysbox on Linux Distributions other than Ubuntu.

Our goal is to allow overlay file-systems to be mounted from within sys containers (i.e. unprivileged user-ns contexts) without the need to rely on external software components such as fuse-overlayfs. Refer to issue #83 for more details: nestybox/sysbox#83.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>