### PR TITLE
Improvements to handle scenarios where multiple sysbox instances run on the same host

### DIFF
--- a/cmd/sysbox-fs/main.go
+++ b/cmd/sysbox-fs/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"os/signal"
 	"runtime"
@@ -220,6 +221,9 @@ func main() {
 
 	// Define 'debug' and 'log' settings.
 	app.Before = func(ctx *cli.Context) error {
+
+		// Random generator seed
+		rand.Seed(time.Now().UnixNano())
 
 		// Create/set the log-file destination.
 		if path := ctx.GlobalString("log"); path != "" {


### PR DESCRIPTION
Normally, we expect one sysbox instance per host. However, some users are
deploying sysbox inside docker containers (aka sysbox-in-docker), meaning that
it's possible to have multiple sysbox instances running concurrently on the same
host.

Such a scenario can lead to a situation where multiple sysbox instances are
writing possibly conflicting values to the kernel's sysctl (i.e., /proc/sys/. To
deal with this situation, this commit implements a heuristic in the sysbox-fs
procfs handlers that reduces (but does not eliminate) the chance that the
kernel's sysctl is programmed incorrectly.

Only the maxIntBaseHandler in sysbox-fs is affected, as it's the only
handler that currently writes to the kernel's sysctl.