### PR TITLE
Streamline sysbox-fs container lifecycle logging.

### DIFF
--- a/ipc/apis.go
+++ b/ipc/apis.go
@@ -63,7 +63,7 @@ func (ips *ipcService) Init() error {
 
 func ContainerPreRegister(ctx interface{}, data *grpc.ContainerData) error {
 
-	logrus.Infof("Container pre-registration message received for id: %s", data.Id)
+	logrus.Debugf("Container pre-registration started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -72,15 +72,14 @@ func ContainerPreRegister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container pre-registration successfully completed for id: %s",
-		data.Id)
+	logrus.Debugf("Container pre-registration completed: id = %s", data.Id)
 
 	return nil
 }
 
 func ContainerRegister(ctx interface{}, data *grpc.ContainerData) error {
 
-	logrus.Infof("Container registration message received for id: %s", data.Id)
+	logrus.Debugf("Container registration started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -103,15 +102,14 @@ func ContainerRegister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container registration successfully completed for id: %s",
-		data.Id)
+	logrus.Infof("Container registration completed: %v", cntr)
 
 	return nil
 }
 
 func ContainerUnregister(ctx interface{}, data *grpc.ContainerData) error {
 
-	logrus.Infof("Container unregistration message received for id: %s", data.Id)
+	logrus.Debugf("Container unregistration started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -130,15 +128,14 @@ func ContainerUnregister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container unregistration successfully completed for id: %s",
-		data.Id)
+	logrus.Infof("Container unregistration completed: id = %s", data.Id)
 
 	return nil
 }
 
 func ContainerUpdate(ctx interface{}, data *grpc.ContainerData) error {
 
-	logrus.Infof("Container update message received for id: %s", data.Id)
+	logrus.Debugf("Container update started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -161,7 +158,7 @@ func ContainerUpdate(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container update successfully processed for id: %s", data.Id)
+	logrus.Debugf("Container update completed: id = %s", data.Id)
 
 	return nil
 }

--- a/state/container.go
+++ b/state/container.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
@@ -132,18 +131,12 @@ func (c *container) InitProc() domain.ProcessIface {
 	return c.initProc
 }
 
-// String() specialization for container type.
 func (c *container) String() string {
 	c.RLock()
 	defer c.RUnlock()
 
-	result := "\n\t\t id: " + c.id + "\n" +
-		"\t\t initPid: " + strconv.Itoa(int(c.initPid)) + "\n" +
-		"\t\t ctime: " + c.ctime.String() + "\n" +
-		"\t\t UID: " + strconv.Itoa(int(c.uidFirst)) + "\n" +
-		"\t\t GID: " + strconv.Itoa(int(c.gidFirst))
-
-	return result
+	return fmt.Sprintf("id = %s, initPid = %d, uid:gid = %v:%v",
+		c.id, int(c.initPid), c.uidFirst, c.gidFirst)
 }
 
 //

--- a/state/containerDB.go
+++ b/state/containerDB.go
@@ -190,8 +190,6 @@ func (css *containerStateService) ContainerRegister(c domain.ContainerIface) err
 	css.usernsTable[usernsInode] = currCntr
 	css.Unlock()
 
-	logrus.Info(cntr.String())
-
 	return nil
 }
 
@@ -218,9 +216,6 @@ func (css *containerStateService) ContainerUpdate(c domain.ContainerIface) error
 	currCntr.SetCtime(cntr.ctime)
 
 	css.Unlock()
-
-	logrus.Info(currCntr.String())
-
 	return nil
 }
 
@@ -292,8 +287,6 @@ func (css *containerStateService) ContainerUnregister(c domain.ContainerIface) e
 	delete(css.idTable, cntr.id)
 	delete(css.usernsTable, usernsInode)
 	css.Unlock()
-
-	logrus.Info(currCntrIdTable.String())
 
 	return nil
 }


### PR DESCRIPTION
This change streamlines sysbox-fs logging for container
related operations. This eases parsing of the logs.

Prior to this chance, logs looked similar to this:

```
INFO[2020-12-08 23:05:17]
                 id: 36f55189d01fb306eef9c486adde3bb63d33f9d1eb49dd1cf52ac959d12689fd
                 initPid: 1692
                 ctime: 0001-01-01 00:00:00 +0000 UTC
                 UID: 165536
                 GID: 165536
INFO[2020-12-08 23:05:17] Container registration successfully completed for id: 36f55189d01fb306eef9c486adde3bb63d33f9d1eb49dd1cf52ac959d12689fd
```

After this change, logs look like this:

```
INFO[2020-12-09 00:20:49] Container registration: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f, initPid = 2765, uid:gid = 165536:165536
INFO[2020-12-09 00:20:53] Container unregistration: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
```

If debug logging is enabled, they look like this:

```
DEBU[2020-12-09 00:20:48] Container pre-registration started: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
DEBU[2020-12-09 00:20:48] Container pre-registration done: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
DEBU[2020-12-09 00:20:49] Container registration started: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
INFO[2020-12-09 00:20:49] Container registration: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f, initPid = 2765, uid:gid = 165536:165536
DEBU[2020-12-09 00:20:49] Container update received: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
DEBU[2020-12-09 00:20:49] Container update done: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
DEBU[2020-12-09 00:20:53] Container unregistration started: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
INFO[2020-12-09 00:20:53] Container unregistration: id = 2068f6174b912975d45b0769a7a6f234ac4f1e641f48a02266b1004792df282f
```

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>