### PR TITLE
Improve the cap_last_cap handler to reduce number of open file descriptors.

### DIFF
--- a/handler/implementations/kernelLastCap.go
+++ b/handler/implementations/kernelLastCap.go
@@ -36,6 +36,10 @@ import (
 // highest capability supported by the running kernel ('37' as of today's
 // latest / 5.X kernels ).
 //
+// This handler is used for performance reasons (rather than functional reasons),
+// as having it avoids using the /proc/sys common handler for accesses to
+// /proc/sys/kernel/cap_last_cap which is the most commonly accessed sysctl.
+//
 type KernelLastCapHandler struct {
 	domain.HandlerBase
 }
@@ -69,22 +73,12 @@ func (h *KernelLastCapHandler) Open(
 		return fuse.IOerror{Code: syscall.EACCES}
 	}
 
-	if err := n.Open(); err != nil {
-		logrus.Debugf("Error opening file %v", h.Path)
-		return fuse.IOerror{Code: syscall.EIO}
-	}
-
 	return nil
 }
 
 func (h *KernelLastCapHandler) Close(n domain.IOnodeIface) error {
 
 	logrus.Debugf("Executing Close() method on %v handler", h.Name)
-
-	if err := n.Close(); err != nil {
-		logrus.Debugf("Error closing file %v", h.Path)
-		return fuse.IOerror{Code: syscall.EIO}
-	}
 
 	return nil
 }


### PR DESCRIPTION
Prior to this change, the sysbox-fs handler for /proc/sys/kernel/cap_last_cap
would open a file descriptor whenever a process in a container opened this
resource. And it would keep it open until the process in the container closed
the resource. Given that cap_last_cap is one of the most (if not the most)
accessed sysctl by processes inside containers, this led to sysbox-fs having a
very large number of file descriptors opened at a given time.

This change improves on this, by having sysbox-fs only open the cap_last_cap
handler when it's value is read, and closes it immediately after.  This
significantly reduces the number of open fds that sysbox-fs has at a any given
time.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>