### PR TITLE
Print key config knobs' settings during initialization

### DIFF
--- a/cmd/sysbox-fs/main.go
+++ b/cmd/sysbox-fs/main.go
@@ -115,7 +115,7 @@ func exitHandler(
 	// Deferring exit() to allow FUSE to dump unnmount() logs
 	time.Sleep(2)
 
-	logrus.Info("Exiting.")
+	logrus.Info("Exiting ...")
 	os.Exit(0)
 }
 
@@ -309,6 +309,18 @@ func main() {
 	app.Action = func(ctx *cli.Context) error {
 
 		logrus.Info("Initiating sysbox-fs ...")
+
+		// Print key configuration knobs settings.
+		if ctx.BoolT("allow-immutable-remounts") {
+			logrus.Info("Initializing with 'allow-immutable-remounts' enabled")
+		} else {
+			logrus.Info("Initializing with 'allow-immutable-remounts' knob disabled (default)")
+		}
+		if ctx.Bool("allow-immutable-unmounts") {
+			logrus.Info("Initializing with 'allow-immutable-unmounts' knob enabled (default)")
+		} else {
+			logrus.Info("Initializing with 'allow-immutable-unmounts' knob disabled")
+		}
 
 		// Construct sysbox-fs services.
 		var nsenterService = nsenter.NewNSenterService()

--- a/ipc/apis.go
+++ b/ipc/apis.go
@@ -55,6 +55,8 @@ func (ips *ipcService) Setup(
 			grpc.ContainerUpdateMessage:      ContainerUpdate,
 		},
 	)
+
+	logrus.Infof("Listening on %v", ips.grpcServer.GetAddr())
 }
 
 func (ips *ipcService) Init() error {


### PR DESCRIPTION
Before:

```
time="2021-02-26 20:07:38" level=info msg="Initiating sysbox-fs ..."
time="2021-02-26 20:07:38" level=info msg="Ready ..."
```

After:

```
time="2021-02-26 21:16:01" level=info msg="Initiating sysbox-fs ..."
time="2021-02-26 21:16:01" level=info msg="Initializing with 'allow-immutable-remounts' knob disabled (default)"
time="2021-02-26 21:16:01" level=info msg="Initializing with 'allow-immutable-unmounts' knob enabled (default)"
time="2021-02-26 21:16:01" level=info msg="Listening on /run/sysbox/sysfs.sock"
time="2021-02-26 21:16:01" level=info msg="Ready ..."
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>