### PR TITLE
Fix for bogus log generated during container registration

### DIFF
--- a/ipc/apis.go
+++ b/ipc/apis.go
@@ -65,8 +65,6 @@ func (ips *ipcService) Init() error {
 
 func ContainerPreRegister(ctx interface{}, data *grpc.ContainerData) error {
 
-	logrus.Debugf("Container pre-registration started: id = %s", data.Id)
-
 	ipcService := ctx.(*ipcService)
 
 	err := ipcService.css.ContainerPreRegister(data.Id)
@@ -74,14 +72,10 @@ func ContainerPreRegister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Debugf("Container pre-registration completed: id = %s", data.Id)
-
 	return nil
 }
 
 func ContainerRegister(ctx interface{}, data *grpc.ContainerData) error {
-
-	logrus.Debugf("Container registration started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -105,14 +99,10 @@ func ContainerRegister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container registration completed: %v", cntr)
-
 	return nil
 }
 
 func ContainerUnregister(ctx interface{}, data *grpc.ContainerData) error {
-
-	logrus.Debugf("Container unregistration started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -131,14 +121,10 @@ func ContainerUnregister(ctx interface{}, data *grpc.ContainerData) error {
 		return err
 	}
 
-	logrus.Infof("Container unregistration completed: id = %s", data.Id)
-
 	return nil
 }
 
 func ContainerUpdate(ctx interface{}, data *grpc.ContainerData) error {
-
-	logrus.Debugf("Container update started: id = %s", data.Id)
 
 	ipcService := ctx.(*ipcService)
 
@@ -161,8 +147,6 @@ func ContainerUpdate(ctx interface{}, data *grpc.ContainerData) error {
 	if err != nil {
 		return err
 	}
-
-	logrus.Debugf("Container update completed: id = %s", data.Id)
 
 	return nil
 }

--- a/state/containerDB.go
+++ b/state/containerDB.go
@@ -101,6 +101,9 @@ func (css *containerStateService) ContainerCreate(
 }
 
 func (css *containerStateService) ContainerPreRegister(id string) error {
+
+	logrus.Debugf("Container pre-registration started: id = %s", id)
+
 	css.Lock()
 
 	// Ensure that new container's id is not already present.
@@ -136,13 +139,18 @@ func (css *containerStateService) ContainerPreRegister(id string) error {
 
 	css.Unlock()
 
+	logrus.Debugf("Container pre-registration completed: id = %s", id)
+
 	return nil
 }
 
 func (css *containerStateService) ContainerRegister(c domain.ContainerIface) error {
-	css.Lock()
 
 	cntr := c.(*container)
+
+	logrus.Debugf("Container registration started: id = %s", cntr.id)
+
+	css.Lock()
 
 	// Ensure that container's id is already present (pregistration completed).
 	currCntr, ok := css.idTable[cntr.id]
@@ -196,13 +204,19 @@ func (css *containerStateService) ContainerRegister(c domain.ContainerIface) err
 	css.usernsTable[usernsInode] = currCntr
 	css.Unlock()
 
+	// No need to allocate cntr's locks as we're printing the temporary one.
+	logrus.Infof("Container registration completed: %v", cntr.string())
+
 	return nil
 }
 
 func (css *containerStateService) ContainerUpdate(c domain.ContainerIface) error {
-	css.Lock()
 
 	cntr := c.(*container)
+
+	logrus.Debugf("Container update started: id = %s", cntr.id)
+
+	css.Lock()
 
 	// Identify the inode associated to the user-ns of the container being
 	// updated.
@@ -222,13 +236,19 @@ func (css *containerStateService) ContainerUpdate(c domain.ContainerIface) error
 	currCntr.SetCtime(cntr.ctime)
 
 	css.Unlock()
+
+	logrus.Debugf("Container update completed: id = %s", cntr.id)
+
 	return nil
 }
 
 func (css *containerStateService) ContainerUnregister(c domain.ContainerIface) error {
-	css.Lock()
 
 	cntr := c.(*container)
+
+	logrus.Debugf("Container unregistration started: id = %s", cntr.id)
+
+	css.Lock()
 
 	// Identify the inode associated to the user-ns of the container being
 	// eliminated.
@@ -293,6 +313,8 @@ func (css *containerStateService) ContainerUnregister(c domain.ContainerIface) e
 	delete(css.idTable, cntr.id)
 	delete(css.usernsTable, usernsInode)
 	css.Unlock()
+
+	logrus.Infof("Container unregistration completed: id = %s", cntr.id)
 
 	return nil
 }


### PR DESCRIPTION
This one is a side effect of a change made a few days ago to fix a potential deadlock situation in container.String() method. At that time i decided to make this method an internal one of the container class, but didn't notice that there was one external package making use of this method.

As a consequence of the above, the following bogus log is now being displayed during container registration:

```
time="2021-02-27 06:18:19" level=info msg="Container registration completed: &{{{0 0} 0 0 0 0} 03eefd5f9d3ea3717727d82c42ba876360529841557ce8a8051d13da191f7d2c 8763 0 {0 0 <nil>} 165536 65536 165536 65536 [/proc/bus /proc/fs /proc/irq /proc/sysrq-trigger] [/proc/asound /proc/acpi /proc/keys /proc/latency_stats /proc/timer_list /proc/timer_stats /proc/sched_debug /proc/scsi] <nil> map[] <nil> 0xc00025a230 {{0 0} 0 0 0 0} {0
```

A proper fix for this one is to avoid the utilization of the container.string() method by external packages, especially when the information being logged is related to properties (registrations / unregistrations) that are owned by the container package itself; this state and associated logs belongs within the container/containerDB realm.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>