### PR TITLE
fix: Use os.Stdout if no logging filename is given

### DIFF
--- a/cmd/sysbox-fs/main.go
+++ b/cmd/sysbox-fs/main.go
@@ -187,8 +187,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "log",
-			Value: "/dev/stdout",
-			Usage: "log file path",
+			Value: "",
+			Usage: "log file path or empty string for stderr output (default: \"\")",
 		},
 		cli.StringFlag{
 			Name:  "log-level",
@@ -264,6 +264,9 @@ func main() {
 
 			logrus.SetOutput(f)
 			log.SetOutput(f)
+		} else {
+			logrus.SetOutput(os.Stderr)
+			log.SetOutput(os.Stderr)
 		}
 
 		if logFormat := ctx.GlobalString("log-format"); logFormat == "json" {


### PR DESCRIPTION
* Use os.Stderr if no logging filename is given
* Set default log to "" to enable stderr output
* This makes it possible to use journald by using default log value
* This solution is not optimal, but keeps backwards compatibility

Refs: https://github.com/nestybox/sysbox/issues/221
