### PR TITLE
Fix deadlock issue around reaper's mutex during async-nsenter execution

### DIFF
--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -132,8 +132,6 @@ type NSenterEventIface interface {
 	SetResponseMsg(m *NSenterMessage)
 	GetResponseMsg() *NSenterMessage
 	GetProcessID() uint32
-	ReapStartRequest()
-	ReapEndRequest()
 }
 
 // NSenterMessage struct defines the layout of the messages being exchanged

--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -132,6 +132,8 @@ type NSenterEventIface interface {
 	SetResponseMsg(m *NSenterMessage)
 	GetResponseMsg() *NSenterMessage
 	GetProcessID() uint32
+	ReapStartRequest()
+	ReapEndRequest()
 }
 
 // NSenterMessage struct defines the layout of the messages being exchanged

--- a/mount/infoParser.go
+++ b/mount/infoParser.go
@@ -302,18 +302,18 @@ func (mi *mountInfoParser) extractMountInfo() ([]byte, error) {
 		&domain.AllNSs,
 		&domain.NSenterMessage{
 			Type:    domain.SleepRequest,
-			Payload: &domain.SleepReqPayload{Ival: strconv.Itoa(5)},
+			Payload: &domain.SleepReqPayload{Ival: strconv.Itoa(30)},
 		},
 		nil,
 		true,
 	)
 
 	// Launch the async nsenter-event.
+	defer asyncEvent.TerminateRequest()
 	err := mi.service.nss.SendRequestEvent(asyncEvent)
 	if err != nil {
 		return nil, err
 	}
-	defer asyncEvent.TerminateRequest()
 
 	// Obtain the pid of the nsenter-event's process.
 	asyncEventPid := mi.service.nss.GetEventProcessID(asyncEvent)

--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -566,14 +566,6 @@ func (e *NSenterEvent) ReceiveResponse() *domain.NSenterMessage {
 	return e.ResMsg
 }
 
-func (e *NSenterEvent) ReapStartRequest() {
-	e.reaper.nsenterStarted()
-}
-
-func (e *NSenterEvent) ReapEndRequest() {
-	e.reaper.nsenterEnded()
-}
-
 // TerminateRequest serves to unwind the nsenter-event FSM after the generation
 // of an asynchronous event. This method is not required for regular nsenter
 // events, as in those cases the SendRequest() method itself takes care of


### PR DESCRIPTION
Problem diagnosis has been well documented as part of issue [#266](https://github.com/nestybox/sysbox/issues/266). Here I'm briefly explaining the fix that I've identified for this bug.

As described in the issue's notes, the problem is caused by a deadlock scenario while dealing with the reaper's RWmutex. The fix is fairly simple: have 'async' nsenter logic remove its reaper's dependency. See that there's no real need for the reaper in the 'async' nsenter case as the SendRequest() callee will always sigkill() the nsenter process, so we can safely remove all this concurrency complexity in this case.

Fix has been heavily tested over the last couple of weeks in the same scaling scenario where the problem was originally reported. No deadlock issues has been observed ever since.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>