### PR TITLE
Fix for issue 291.

### DIFF
--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -814,21 +814,8 @@ func (e *NSenterEvent) processMountSyscallRequest() error {
 		}
 	}
 
-	process := e.service.prs.ProcessCreate(e.Pid, 0, 0)
-
 	// Perform mount instructions.
 	for i = 0; i < len(payload); i++ {
-
-		payload[i].Source, err = process.ResolveProcSelf(payload[i].Source)
-		if err != nil {
-			break
-		}
-
-		payload[i].Target, err = process.ResolveProcSelf(payload[i].Target)
-		if err != nil {
-			break
-		}
-
 		err = unix.Mount(
 			payload[i].Source,
 			payload[i].Target,
@@ -878,16 +865,9 @@ func (e *NSenterEvent) processUmountSyscallRequest() error {
 	)
 
 	payload := e.ReqMsg.Payload.([]domain.UmountSyscallPayload)
-	process := e.service.prs.ProcessCreate(e.Pid, 0, 0)
 
 	// Perform umount instructions.
 	for i = 0; i < len(payload); i++ {
-
-		payload[i].Target, err = process.ResolveProcSelf(payload[i].Target)
-		if err != nil {
-			break
-		}
-
 		err = unix.Unmount(
 			payload[i].Target,
 			int(payload[i].Flags),
@@ -922,16 +902,9 @@ func (e *NSenterEvent) processUmountSyscallRequest() error {
 func (e *NSenterEvent) processChownSyscallRequest() error {
 
 	payload := e.ReqMsg.Payload.([]domain.ChownSyscallPayload)
-	process := e.service.prs.ProcessCreate(e.Pid, 0, 0)
 
 	for _, p := range payload {
 		var err error
-
-		p.Target, err = process.ResolveProcSelf(p.Target)
-		if err != nil {
-			break
-		}
-
 		if err = unix.Chown(p.Target, p.TargetUid, p.TargetGid); err != nil {
 			e.ResMsg = &domain.NSenterMessage{
 				Type:    domain.ErrorResponse,

--- a/process/process.go
+++ b/process/process.go
@@ -630,7 +630,7 @@ func (p *process) getStatus(fields []string) error {
 // pointed to by symlink. For example, if path is "/proc/self/fd/3" and
 // "/proc/self/fd/3" is a symlink to "/some/path", then this function returns
 // "/some/path". Note that "self" refers to the process struct, so we replace
-// "self" with p.pid.  The path resolution is recursive: E.g., if
+// "self" with p.pid. The path resolution is recursive: E.g., if
 // "/proc/self/fd/3" symlink points to "/proc/self/cwd", and "/proc/self/cwd"
 // points to "/some/path", this function follows the symlinks and returns
 // "/some/path".
@@ -638,12 +638,7 @@ func (p *process) getStatus(fields []string) error {
 func (p *process) ResolveProcSelf(path string) (string, error) {
 
 	// TODO: this function is not capable of dealing with relative paths
-	// "../../proc/self/fd/X". It also assumes procfs is mounted on /proc, so
-	// it's not capable of dealing with scenarios where something else is mounted
-	// on /proc (rare), or where procfs is mounted at a different location (e.g.,
-	// /root/proc/self). We need to improve it to deal with these issues (likely
-	// by doing a filepath walk of each component of the path, and resolving
-	// "self" when we are sure it's under a procfs mount).
+	// "../../proc/self/fd/X". It also assumes procfs is mounted on /proc.
 
 	for {
 		if !strings.HasPrefix(path, "/proc/self/") {
@@ -653,26 +648,15 @@ func (p *process) ResolveProcSelf(path string) (string, error) {
 		procPid := fmt.Sprintf("/proc/%d/", p.pid)
 		procPidPath := strings.Replace(path, "/proc/self/", procPid, 1)
 
-		// Resolve the procfs symlink, then append the rest of the path (e.g., if
-		// /proc/<pid>/fd/5 is a symlink to /some/path, then given path
-		// /proc/<pid>/fd/5/another/path, we should resolve to
-		// /some/path/another/path.
+		err := filepath.Walk(procPidPath, func(walkPath string, fi os.FileInfo, err error) error {
 
-		components := strings.Split(procPidPath, "/")
-		procPidNext := procPid + components[3]
-
-		err := filepath.Walk(procPidNext, func(walkPath string, fi os.FileInfo, err error) error {
-
-			if strings.Contains(procPidPath, walkPath) {
-				isSymlink := fi.Mode()&os.ModeSymlink == os.ModeSymlink
-				if isSymlink {
-					resolvedPath, err := os.Readlink(walkPath)
-					if err != nil {
-						return err
-					}
-					path = strings.Replace(procPidPath, walkPath, resolvedPath, 1)
-					return nil
+			isSymlink := fi.Mode()&os.ModeSymlink == os.ModeSymlink
+			if isSymlink {
+				resolvedPath, err := os.Readlink(walkPath)
+				if err != nil {
+					return err
 				}
+				path = strings.Replace(procPidPath, walkPath, resolvedPath, 1)
 			}
 
 			return nil


### PR DESCRIPTION
These two changes fix issue 291 (i.e., launching container inside a sysbox container fails when using the latest OCI runc (v1.0.0-rc95)).