### PR TITLE
Fix bug in nsenter namespace path composition.

### DIFF
--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -357,11 +357,7 @@ func (e *NSenterEvent) namespacePaths() []string {
 	// always first.
 
 	for _, nstype := range *(e.Namespace) {
-		path := filepath.Join(
-			nstype,
-			":/proc/",
-			strconv.Itoa(int(e.Pid)), "/ns/",
-			nstype)
+		path := nstype + ":" + filepath.Join("/proc", strconv.Itoa(int(e.Pid)), "/ns", nstype)
 		paths = append(paths, path)
 	}
 


### PR DESCRIPTION
Prior to this change, sysbox-fs was creating the nsenter
paths with an extra "/" which can confuse the nsenter
process:

user/:/proc/57167/ns/user

This commit fixes it to:

user:/proc/57167/ns/user

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>