### PR TITLE
Add config option to release seccomp-notify fd handles on container exit

### DIFF
--- a/cmd/sysbox-fs/main.go
+++ b/cmd/sysbox-fs/main.go
@@ -186,6 +186,11 @@ func main() {
 			Usage: "sys container's initial mounts are considered immutable; this option allows them to be unmounted from within the container (default: \"true\")",
 		},
 		cli.StringFlag{
+			Name:  "seccomp-fd-release",
+			Value: "proc-exit",
+			Usage: "Policy to close syscall interception handles; allowed values are \"proc-exit\" and \"cont-exit\" (default = \"proc-exit\")",
+		},
+		cli.StringFlag{
 			Name:  "log",
 			Value: "",
 			Usage: "log file path or empty string for stderr output (default: \"\")",
@@ -326,6 +331,9 @@ func main() {
 		} else {
 			logrus.Info("Initializing with 'allow-immutable-unmounts' knob disabled")
 		}
+		if ctx.GlobalString("seccomp-fd-release") == "cont-exit" {
+			logrus.Info("Seccomp-notify fd release policy set to container exit")
+		}
 
 		// Construct sysbox-fs services.
 		var nsenterService = nsenter.NewNSenterService()
@@ -380,6 +388,7 @@ func main() {
 			mountService,
 			ctx.BoolT("allow-immutable-remounts"),
 			ctx.Bool("allow-immutable-unmounts"),
+			ctx.GlobalString("seccomp-fd-release"),
 		)
 
 		ipcService.Setup(


### PR DESCRIPTION
This commit adds a config option to sysbox-fs called "seccomp-fd-release". It
solves the problem of syscall interception not working when a process execs into
a container, forks children, and then dies, causing sysbox to close the syscall
interception handle (seccomp-notify fd) and thus breaking syscall interception
for the children processes.

When set to "cont-exit" (container exit), sysbox-fs will not close the
syscall interception handle when the associated process dies but instead will
keep it open until the associated container stops, solving the exec problem. By
default, this option is set to "proc-exit" (process exit), meaning that
sysbox-fs closes the syscall interception handle as soon as the associated
process dies (i.e., no change in the behavior prior to this change).

While setting this new config option to "cont-exit" fixes the problem described
above, the drawback that this causes kernel resources associated with that
handle to be kept around even after the associated process has died. For long
living containers where lot's of processes exec into the container, this could
be a problem so it's not recommended.  However, for short lived containers where
processes exec into the container, this should be fine.

Note that this config option is expected to be temporary because starting in
kernel >= 5.8, there is a kernel mechanism to help sysbox determine when *all*
processes associated with a given seccomp notify fd have died, thus solving the
problem described above. As a result, this option is expected to be deprecated
(or become useless) in the future.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>