### PR TITLE
Relax a couple of logging instructions to reduce unnecessary noise

### DIFF
--- a/seccomp/tracer.go
+++ b/seccomp/tracer.go
@@ -372,7 +372,7 @@ func (t *syscallTracer) connHandler(c *net.UnixConn) error {
 		// Return here to exit this goroutine in case of error as that implies
 		// that the seccomp-fd is not valid anymore.
 		if err := t.seccompSessionRead(seccompSession); err != nil {
-			logrus.Warnf("Failed to wait for seccomp session: %v", err)
+			logrus.Debugf("Failed to wait for seccomp session: %v", err)
 			return err
 		}
 
@@ -478,7 +478,7 @@ func (t *syscallTracer) process(
 
 	// TOCTOU check.
 	if err := libseccomp.NotifIdValid(libseccomp.ScmpFd(fd), req.Id); err != nil {
-		logrus.Warnf("TOCTOU check failed on fd %d pid %d cntr %s: req.Id is no longer valid (%s)",
+		logrus.Infof("TOCTOU check failed on fd %d pid %d cntr %s: req.Id is no longer valid (%s)",
 			fd, req.Pid, formatter.ContainerID{cntrID}, err)
 		return t.createErrorResponse(req.Id, err)
 	}


### PR DESCRIPTION
```
time="2021-07-07 19:31:49" level=warning msg="Failed to wait for seccomp session: Interrupted poll operation: closed file-descriptor"
time="2021-07-07 19:33:08" level=warning msg="Failed to wait for seccomp session: Interrupted poll operation: closed file-descriptor"
time="2021-07-07 19:34:12" level=warning msg="Failed to wait for seccomp session: Interrupted poll operation: closed file-descriptor"
time="2021-07-07 19:57:47" level=warning msg="Failed to wait for seccomp session: Interrupted poll operation: closed file-descriptor"
```

```
time="2021-07-04 17:30:32" level=warning msg="TOCTOU check failed on fd 74 pid 31949 cntr 21842f8de4fa: req.Id is no longer valid (no such file or directory)"
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>