### PR TITLE
Fix build with GOFLAGS="-mod=readonly" (default in Go 1.16+)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/capability v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/dockerUtils v0.0.0-00010101000000-000000000000
-	github.com/nestybox/sysbox-libs/formatter v0.0.0-20210407172909-16033800cb3d
+	github.com/nestybox/sysbox-libs/formatter v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/libseccomp-golang v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/pidmonitor v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-runc v0.0.0-00010101000000-000000000000
@@ -39,6 +39,8 @@ replace github.com/nestybox/sysbox-runc => ../sysbox-runc
 replace github.com/nestybox/sysbox-libs/utils => ../sysbox-libs/utils
 
 replace github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
+
+replace github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
 
 replace github.com/nestybox/sysbox-libs/libseccomp-golang => ../sysbox-libs/libseccomp-golang
 

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,6 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nestybox/sysbox-libs v0.0.0-20210407172909-16033800cb3d h1:o/a9z2qWxDWUsuZLiPm8raOEdM24zQR54pqmUfiTJW0=
-github.com/nestybox/sysbox-libs/formatter v0.0.0-20210407172909-16033800cb3d h1:ewzQbpo26gz6FlkeDcU6BI83SZpyB9Lt3sl/eT8VcUM=
-github.com/nestybox/sysbox-libs/formatter v0.0.0-20210407172909-16033800cb3d/go.mod h1:/ILpO0gYqOe73l4elvX2Jvrnym4ePdIcnKlPZmYCRcY=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
When building sysbox-runc, the build depends on the Golang import lookup feature to resolve the internal sysbox-libs/formatter module, the following lines are shown on the log when building with "make sysbox":

```
go: finding github.com/nestybox/sysbox-libs latest
go: finding github.com/nestybox/sysbox-libs/formatter latest
```

(It appears to be downloading the latest version which may cause flakyness?)

If using GOFLAGS="-mod=readonly" (default in Go 1.16+), the build fails with:

```
build github.com/nestybox/sysbox-runc: cannot load github.com/nestybox/sysbox-libs/formatter: import lookup disabled by -mod=readonly
```

Explicitly use the local sysbox-libs/formatter module (similarly to sysbox-libs/dockerUtils) to avoid this problem.


The change also applies to sysbox-fs because it depends on sysbox-runc.
