### PR TITLE
Fix bug preventing ARM platforms from being able to read RO procfs nodes

### DIFF
--- a/handler/implementations/proc.go
+++ b/handler/implementations/proc.go
@@ -112,7 +112,8 @@ func (h *Proc) Open(
 		return nil
 
 	case "swaps", "uptime":
-		if flags != syscall.O_RDONLY {
+               if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
+                  flags&syscall.O_RDWR == syscall.O_RDWR {
 			return fuse.IOerror{Code: syscall.EACCES}
 		}
 	}

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -296,7 +296,8 @@ func (h *ProcSysKernel) Open(
 
 	switch resource {
 	case "cap_last_cap":
-		if flags != syscall.O_RDONLY {
+		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
+		   flags&syscall.O_RDWR == syscall.O_RDWR {
 			return fuse.IOerror{Code: syscall.EACCES}
 		}
 		return nil
@@ -305,7 +306,8 @@ func (h *ProcSysKernel) Open(
 		return nil
 
 	case "ngroups_max":
-		if flags != syscall.O_RDONLY {
+		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
+		   flags&syscall.O_RDWR == syscall.O_RDWR {
 			return fuse.IOerror{Code: syscall.EACCES}
 		}
 		return nil

--- a/handler/implementations/sysDevicesVirtualDmiId.go
+++ b/handler/implementations/sysDevicesVirtualDmiId.go
@@ -112,7 +112,8 @@ func (h *SysDevicesVirtualDmiId) Open(
 		req.ID, h.Name, resource)
 
 	flags := n.OpenFlags()
-	if flags != syscall.O_RDONLY {
+	if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
+	   flags&syscall.O_RDWR == syscall.O_RDWR {
 		return fuse.IOerror{Code: syscall.EACCES}
 	}
 


### PR DESCRIPTION
Discovered this one while running some preliminary tests on ARM platforms. It turns out that 'cat' application when running over ARM, seems to be calling open() with "O_READ | O_NOFOLLOW" flags, which resulted in Sysbox returning an EACCESS back to the user (which can be easily explained by looking at the existing code).

This same bug can be potentially seen in AMD64 arch too, but we haven't run into this till we started to play with ARM.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>