### PR TITLE
Optimization to expedite registration process

### DIFF
--- a/domain/container.go
+++ b/domain/container.go
@@ -37,6 +37,8 @@ type ContainerIface interface {
 	ProcMaskPaths() []string
 	InitProc() ProcessIface
 	ExtractInode(path string) (Inode, error)
+	IsMountInfoInitialized() bool
+	InitializeMountInfo() error
 	IsImmutableMount(info *MountInfo) bool
 	IsImmutableRoMount(info *MountInfo) bool
 	IsImmutableMountID(id int) bool

--- a/seccomp/mount.go
+++ b/seccomp/mount.go
@@ -49,6 +49,16 @@ func (m *mountSyscallInfo) process() (*sysResponse, error) {
 	// Adjust mount attributes attending to the process' root path.
 	m.targetAdjust()
 
+	// Ensure that the mountInfoDB corresponding to the sys-container hosting
+	// this process has been already built. This info is necessary to be able
+	// to discern between 'initial' and 'regular' mounts, which is required
+	// for the proper operation of the mount-hardening feature.
+	if !m.cntr.IsMountInfoInitialized() {
+		if err := m.cntr.InitializeMountInfo(); err != nil {
+			return nil, err
+		}
+	}
+
 	// Handle requests that create a new mountpoint for filesystems managed by
 	// sysbox-fs.
 	if mh.IsNewMount(m.Flags) {

--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -54,6 +54,16 @@ func (u *umountSyscallInfo) process() (*sysResponse, error) {
 		return nil, fmt.Errorf("unexpected mount-service handler")
 	}
 
+	// Ensure that the mountInfoDB corresponding to the sys-container hosting
+	// this process has been already built. This info is necessary to be able
+	// to discern between 'initial' and 'regular' mounts, which is required
+	// for the proper operation of the mount-hardening feature.
+	if !u.cntr.IsMountInfoInitialized() {
+		if err := u.cntr.InitializeMountInfo(); err != nil {
+			return nil, err
+		}
+	}
+
 	mip, err := mts.NewMountInfoParser(u.cntr, u.processInfo, true, true, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The goal here is to further optimize the container registration logic to ensure that no errors are seen at sys-container creation. We have increasingly observed spurious errors in scaling setups with messages like this one generated by the high-layer runtime (docker in this case):

"failed to pre-register container with sysbox-fs: rpc error: code = DeadlineExceeded desc = context deadline exceeded"

Most of these were a direct consequence of the extra delay incurred by sysbox-fs to obtain the 'inodes' associated to the initial mountpoints of a sys-container. This logic helps Sysbox discern between the 'initial' mountpoints (which we treat as 'immutables') and those that are created by the user after initialization.

With these changes I'm now making this process "lazy" by deferring the mountpoint classification logic till the first mount (or umount) syscall is generated. See that there's no security implications here as Sysbox is already intercepting all the mount / umount syscalls, so no (u)mount syscall will ever proceed without first completing the mount-classification process.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>