### PR TITLE
Refactor sysbox-fs FUSE handlers.

### DIFF
--- a/domain/container.go
+++ b/domain/container.go
@@ -30,7 +30,7 @@ type ContainerIface interface {
 	ID() string
 	InitPid() uint32
 	Ctime() time.Time
-	Data(path string, name string) (string, bool)
+	Data(name string, offset int64, data *[]byte) (int, error)
 	UID() uint32
 	GID() uint32
 	ProcRoPaths() []string
@@ -51,7 +51,7 @@ type ContainerIface interface {
 	//
 	// Setters
 	//
-	SetData(path string, name string, data string)
+	SetData(name string, offset int64, data []byte) error
 	SetInitProc(pid, uid, gid uint32) error
 	//
 	// Locks for read-modify-write operations on container data via the Data()
@@ -60,13 +60,6 @@ type ContainerIface interface {
 	Lock()
 	Unlock()
 }
-
-//
-// Auxiliary types to deal with the per-container-state associated to all the
-// emulated resources.
-//
-type StateDataMap = map[string]map[string]string
-type StateData = map[string]string
 
 //
 // ContainerStateService interface defines the APIs that sysbox-fs components

--- a/domain/ionode.go
+++ b/domain/ionode.go
@@ -51,10 +51,12 @@ type IOnodeIface interface {
 	Read(p []byte) (n int, err error)
 	Write(p []byte) (n int, err error)
 	Close() error
+	Seek(offset int64, whence int) (int64, error)
 	ReadAt(p []byte, off int64) (n int, err error)
 	ReadDirAll() ([]os.FileInfo, error)
 	ReadFile() ([]byte, error)
 	ReadLine() (string, error)
+	WriteAt(p []byte, off int64) (n int, err error)
 	WriteFile(p []byte) error
 	Mkdir() error
 	MkdirAll() error

--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -170,13 +170,15 @@ type OpenFilePayload struct {
 }
 
 type ReadFilePayload struct {
-	File    string `json:"file"`
-	Content string `json:"content"`
+	File   string `json:"file"`
+	Offset int64  `json:"offset"`
+	Len    int    `json:"len"`
 }
 
 type WriteFilePayload struct {
-	File    string `json:"file"`
-	Content string `json:"content"`
+	File   string `json:"file"`
+	Offset int64  `json:"offset"`
+	Data   []byte `json:"data"`
 }
 
 type ReadDirPayload struct {

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -204,9 +204,6 @@ func (f *File) Read(
 
 	ionode := f.server.service.ios.NewIOnode(f.name, f.path, f.attr.Mode)
 
-	// Adjust receiving buffer to the request's size.
-	resp.Data = resp.Data[:req.Size]
-
 	// Identify the associated handler and execute it accordingly.
 	handler, ok := f.server.service.hds.LookupHandler(ionode)
 	if !ok {
@@ -220,7 +217,7 @@ func (f *File) Read(
 		Uid:       req.Uid,
 		Gid:       req.Gid,
 		Offset:    req.Offset,
-		Data:      resp.Data,
+		Data:      make([]byte, req.Size),
 		Container: f.server.container,
 	}
 
@@ -231,8 +228,7 @@ func (f *File) Read(
 		return err
 	}
 
-	resp.Data = resp.Data[:n]
-
+	resp.Data = request.Data[:n]
 	return nil
 }
 
@@ -281,7 +277,6 @@ func (f *File) Write(
 	}
 
 	resp.Size = n
-
 	return nil
 }
 

--- a/handler/implementations/passThrough_test.go
+++ b/handler/implementations/passThrough_test.go
@@ -491,7 +491,9 @@ func TestPassThrough_Read(t *testing.T) {
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.ReadFileRequest,
 						Payload: &domain.ReadFilePayload{
-							File: a1.n.Path(),
+							File:   a1.n.Path(),
+							Offset: 0,
+							Len:    len(string("file content 0123456789")),
 						},
 					},
 				}
@@ -500,7 +502,7 @@ func TestPassThrough_Read(t *testing.T) {
 				nsenterEventResp := &nsenter.NSenterEvent{
 					ResMsg: &domain.NSenterMessage{
 						Type:    domain.ReadFileResponse,
-						Payload: string("file content 0123456789"),
+						Payload: []byte("file content 0123456789"),
 					},
 				}
 
@@ -624,8 +626,9 @@ func TestPassThrough_Write(t *testing.T) {
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.WriteFileRequest,
 						Payload: &domain.WriteFilePayload{
-							File:    a1.n.Path(),
-							Content: "file content 0123456789",
+							File:   a1.n.Path(),
+							Offset: 0,
+							Data:   []byte("file content 0123456789"),
 						},
 					},
 				}
@@ -675,8 +678,9 @@ func TestPassThrough_Write(t *testing.T) {
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.WriteFileRequest,
 						Payload: &domain.WriteFilePayload{
-							File:    a1.n.Path(),
-							Content: "file content 0123456789",
+							File:   a1.n.Path(),
+							Offset: 0,
+							Data:   []byte("file content 0123456789"),
 						},
 					},
 				}

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -355,34 +355,34 @@ func (h *ProcSysKernel) Read(
 
 	switch resource {
 	case "cap_last_cap":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "pid_max":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "ngroups_max":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "domainname":
-		return readFileString(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "hostname":
-		return readFileString(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "kptr_restrict":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "panic":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "panic_on_oops":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "sysrq":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "printk":
-		return readFileString(h, n, req)
+		return readCntrData(h, n, req)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -406,28 +406,37 @@ func (h *ProcSysKernel) Write(
 		return 0, nil
 
 	case "pid_max":
-		return writeFileMaxInt(h, n, req, false)
+		return writeCntrData(h, n, req, nil)
 
 	case "panic":
-		return writeFileString(h, n, req, false)
+		return writeCntrData(h, n, req, nil)
 
 	case "printk":
-		return writeFileString(h, n, req, false)
+		return writeCntrData(h, n, req, nil)
 
 	case "panic_on_oops":
-		return writeFileInt(h, n, req, minPanicOopsVal, maxPanicOopsVal, false)
+		// Even though only values 0 and 1 are defined for panic_on_oops, the
+		// kernel allows other values to be written; thus no range check is
+		// performed here.
+		return writeCntrData(h, n, req, nil)
 
 	case "kptr_restrict":
-		return writeFileInt(h, n, req, minRestrictVal, maxRestrictVal, false)
+		if !checkIntRange(req.Data, minRestrictVal, maxRestrictVal) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 
 	case "sysrq":
-		return writeFileInt(h, n, req, minSysrqVal, maxSysrqVal, false)
+		if !checkIntRange(req.Data, minSysrqVal, maxSysrqVal) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 
 	case "domainname":
-		return writeFileString(h, n, req, false)
+		return writeCntrData(h, n, req, nil)
 
 	case "hostname":
-		return writeFileString(h, n, req, false)
+		return writeCntrData(h, n, req, nil)
 	}
 
 	// Refer to generic handler if no node match is found above.

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -142,10 +142,10 @@ func (h *ProcSysNetCore) Read(
 
 	switch resource {
 	case "default_qdisc":
-		return readFileString(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "somaxconn":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -166,7 +166,7 @@ func (h *ProcSysNetCore) Write(
 		return h.writeDefaultQdisc(n, req)
 
 	case "somaxconn":
-		return writeFileMaxInt(h, n, req, true)
+		return writeCntrData(h, n, req, writeMaxIntToFs)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -270,5 +270,5 @@ func (h *ProcSysNetCore) writeDefaultQdisc(
 		return 0, fuse.IOerror{Code: syscall.EINVAL}
 	}
 
-	return writeFileString(h, n, req, false)
+	return writeCntrData(h, n, req, writeToFs)
 }

--- a/handler/implementations/procSysNetIpv4Neigh.go
+++ b/handler/implementations/procSysNetIpv4Neigh.go
@@ -22,11 +22,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/nestybox/sysbox-fs/domain"
+	"github.com/nestybox/sysbox-fs/fuse"
 )
 
 //
@@ -162,7 +164,7 @@ func (h *ProcSysNetIpv4Neigh) Read(
 			&domain.EmuResource{Kind: domain.FileEmuResource, Mode: os.FileMode(uint32(0644))}
 	}
 
-	return readFileInt(h, n, req)
+	return readCntrData(h, n, req)
 }
 
 func (h *ProcSysNetIpv4Neigh) Write(
@@ -195,7 +197,11 @@ func (h *ProcSysNetIpv4Neigh) Write(
 			&domain.EmuResource{Kind: domain.FileEmuResource, Mode: os.FileMode(uint32(0644))}
 	}
 
-	return writeFileInt(h, n, req, 0, MaxInt, false)
+	if !checkIntRange(req.Data, 0, MaxInt) {
+		return 0, fuse.IOerror{Code: syscall.EINVAL}
+	}
+
+	return writeCntrData(h, n, req, nil)
 }
 
 func (h *ProcSysNetIpv4Neigh) ReadDirAll(

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -21,11 +21,13 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/nestybox/sysbox-fs/domain"
+	"github.com/nestybox/sysbox-fs/fuse"
 )
 
 //
@@ -138,16 +140,16 @@ func (h *ProcSysNetIpv4Vs) Read(
 
 	switch resource {
 	case "conntrack":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "conn_reuse_mode":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "expire_nodest_conn":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "expire_quiescent_template":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -165,16 +167,25 @@ func (h *ProcSysNetIpv4Vs) Write(
 
 	switch resource {
 	case "conntrack":
-		return writeFileMaxInt(h, n, req, true)
+		return writeCntrData(h, n, req, writeMaxIntToFs)
 
 	case "conn_reuse_mode":
-		return writeFileInt(h, n, req, minConnReuseMode, maxConnReuseMode, false)
+		if !checkIntRange(req.Data, minConnReuseMode, maxConnReuseMode) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 
 	case "expire_nodest_conn":
-		return writeFileInt(h, n, req, MinInt, MaxInt, false)
+		if !checkIntRange(req.Data, MinInt, MaxInt) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 
 	case "expire_quiescent_template":
-		return writeFileInt(h, n, req, MinInt, MaxInt, false)
+		if !checkIntRange(req.Data, MinInt, MaxInt) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 	}
 
 	// Refer to generic handler if no node match is found above.

--- a/handler/implementations/procSysNetUnix.go
+++ b/handler/implementations/procSysNetUnix.go
@@ -114,7 +114,7 @@ func (h *ProcSysNetUnix) Read(
 
 	switch resource {
 	case "max_dgram_qlen":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -132,7 +132,7 @@ func (h *ProcSysNetUnix) Write(
 
 	switch resource {
 	case "max_dgram_qlen":
-		return writeFileMaxInt(h, n, req, true)
+		return writeCntrData(h, n, req, writeMaxIntToFs)
 	}
 
 	// Refer to generic handler if no node match is found above.

--- a/handler/implementations/procSysVm.go
+++ b/handler/implementations/procSysVm.go
@@ -21,11 +21,13 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/nestybox/sysbox-fs/domain"
+	"github.com/nestybox/sysbox-fs/fuse"
 )
 
 //
@@ -144,10 +146,10 @@ func (h *ProcSysVm) Read(
 
 	switch resource {
 	case "overcommit_memory":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 
 	case "mmap_min_addr":
-		return readFileInt(h, n, req)
+		return readCntrData(h, n, req)
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -174,10 +176,16 @@ func (h *ProcSysVm) Write(
 		//    also improves memory-intensive workloads.
 		// 2: Kernel will not overcommit memory, and only allocate as much memory as
 		//    defined in overcommit_ratio.
-		return writeFileInt(h, n, req, minOvercommitMem, maxOverCommitMem, false)
+		if !checkIntRange(req.Data, minOvercommitMem, maxOverCommitMem) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 
 	case "mmap_min_addr":
-		return writeFileInt(h, n, req, 0, MaxInt, false)
+		if !checkIntRange(req.Data, 0, MaxInt) {
+			return 0, fuse.IOerror{Code: syscall.EINVAL}
+		}
+		return writeCntrData(h, n, req, nil)
 	}
 
 	// Refer to generic handler if no node match is found above.

--- a/handler/implementations/sysModuleNfconntrackParameters.go
+++ b/handler/implementations/sysModuleNfconntrackParameters.go
@@ -101,7 +101,7 @@ func (h *SysModuleNfconntrackParameters) Read(
 		return 0, io.EOF
 	}
 
-	return readFileInt(h, n, req)
+	return readCntrData(h, n, req)
 }
 
 func (h *SysModuleNfconntrackParameters) Write(
@@ -113,7 +113,7 @@ func (h *SysModuleNfconntrackParameters) Write(
 	logrus.Debugf("Executing Write() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
 
-	return writeFileMaxInt(h, n, req, true)
+	return writeCntrData(h, n, req, writeToFs)
 }
 
 func (h *SysModuleNfconntrackParameters) ReadDirAll(

--- a/sysio/ionodeFile.go
+++ b/sysio/ionodeFile.go
@@ -109,7 +109,7 @@ func (i *IOnodeFile) Open() error {
 	return nil
 }
 
-func (i *IOnodeFile) Read(p []byte) (n int, err error) {
+func (i *IOnodeFile) Read(p []byte) (int, error) {
 
 	if i.file == nil {
 		return 0, fmt.Errorf("File not currently opened.")
@@ -119,7 +119,7 @@ func (i *IOnodeFile) Read(p []byte) (n int, err error) {
 
 }
 
-func (i *IOnodeFile) Write(p []byte) (n int, err error) {
+func (i *IOnodeFile) Write(p []byte) (int, error) {
 
 	if i.file == nil {
 		return 0, fmt.Errorf("File not currently opened.")
@@ -135,6 +135,15 @@ func (i *IOnodeFile) Close() error {
 	}
 
 	return i.file.Close()
+}
+
+func (i *IOnodeFile) Seek(offset int64, whence int) (int64, error) {
+
+	if i.file == nil {
+		return 0, fmt.Errorf("File not currently opened.")
+	}
+
+	return i.file.Seek(int64(offset), whence)
 }
 
 func (i *IOnodeFile) ReadAt(p []byte, off int64) (n int, err error) {
@@ -190,6 +199,15 @@ func (i *IOnodeFile) ReadLine() (string, error) {
 	res = scanner.Text()
 
 	return res, nil
+}
+
+func (i *IOnodeFile) WriteAt(p []byte, off int64) (n int, err error) {
+
+	if i.file == nil {
+		return 0, fmt.Errorf("File not currently opened.")
+	}
+
+	return i.file.WriteAt(p, off)
 }
 
 func (i *IOnodeFile) WriteFile(p []byte) error {


### PR DESCRIPTION
This change does several improvements in the sysbox-fs FUSE handlers
(used for emulating accesses to the sys container's /proc/sys).

These improvements are:

* The handlers now treat the data as a bunch of bytes, rather than more specific
  data types (e.g., int, string, etc).

* Since data is now treated as bytes, several redundant functions that dealt
  with treating data as strings or integers are no longer needed. This reduces
  repetition in the code.

* The handlers can now deal with data offsets (i.e., if the container wants
  to read/write a resource under /proc/sys at offsets other than zero).
  This is possible.

* The caching of handler data in the container object is now done using bytes
  too; this simplifies the caching.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>