### PR TITLE
Fix issue preventing get/listxattr() syscalls from being properly handled within a sys-container

### DIFF
--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -208,6 +208,7 @@ type SetxattrSyscallPayload struct {
 }
 
 type GetxattrSyscallPayload struct {
+	Header  NSenterMsgHeader
 	Syscall string `json:"syscall"`
 	Path    string `json:"path"`
 	Name    string `json:"name"`
@@ -226,6 +227,7 @@ type RemovexattrSyscallPayload struct {
 }
 
 type ListxattrSyscallPayload struct {
+	Header  NSenterMsgHeader
 	Syscall string `json:"syscall"`
 	Path    string `json:"path"`
 	Size    uint64 `json:"size"`

--- a/nsenter/event.go
+++ b/nsenter/event.go
@@ -847,7 +847,7 @@ func (e *NSenterEvent) processMountSyscallRequest() error {
 		// executing this logic.
 		this := e.service.prs.ProcessCreate(0, 0, 0)
 
-		// Adjust 'nsenter' process personality to match the end-user's original
+		// Adjust 'nsenter' process personality to match the container's original
 		// process.
 		if err := this.AdjustPersonality(
 			header.Uid,
@@ -1014,7 +1014,7 @@ func (e *NSenterEvent) processGetxattrSyscallRequest() error {
 	// executing this logic.
 	this := e.service.prs.ProcessCreate(0, 0, 0)
 
-	// Adjust 'nsenter' process personality to match the end-user's original
+	// Adjust 'nsenter' process personality to match the container's original
 	// process.
 	if err := this.AdjustPersonality(
 		p.Header.Uid,
@@ -1097,7 +1097,7 @@ func (e *NSenterEvent) processListxattrSyscallRequest() error {
 	// executing this logic.
 	this := e.service.prs.ProcessCreate(0, 0, 0)
 
-	// Adjust 'nsenter' process personality to match the end-user's original
+	// Adjust 'nsenter' process personality to match the container's original
 	// process.
 	if err := this.AdjustPersonality(
 		p.Header.Uid,

--- a/seccomp/tracer.go
+++ b/seccomp/tracer.go
@@ -1228,13 +1228,13 @@ func (t *syscallTracer) parseByteArgs(pid uint32, argPtrs []uint64, argSize []ui
 	return result, nil
 }
 
-func (t *syscallTracer) WriteRetVal(pid uint32, addr uint64, data []byte) error {
-
-	size := len(data)
+func (t *syscallTracer) WriteRetVal(pid uint32, addr uint64, data []byte, size int) error {
 
 	if size == 0 {
 		return nil
 	}
+
+	data = data[:size]
 
 	localIov := []unix.Iovec{
 		{


### PR DESCRIPTION
Problem may be reproduced in scenarios where a considerable number of getxattr() and/or listxattr() syscalls are launched within a sys-container. Notice that Sysbox's proper operation isn't affected in any way during problem reproduction -- only the user process generating the syscalls may be impacted.

These syscalls are utilized to fetch the extended-attributes (xattrs) associated to any node within a file-system, and processes invoking them usually obtain this state in two steps: 1) A first syscall is made to obtain the size of the xattrs elements that the kernel is aware of for any given node, and 2) Based on the 'size' attribute obtained in 1), the user process allocates enough memory to hold these upcoming xattrs, and then it executes a second syscall to obtain the actual state from the kernel.

An important aspect to keep in mind is that the size of the xattrs returned in 2) may be a subset of the one returned by 1). This is a result of the kernel waiting till 2) to filter the xattrs that may be 'seen' by a given process based on its credentials/capabilities. Refer to xattr(7) for details.

As can be seen in the following strace capture, the problem is reproduced when the list of returned xattrs in 2) is nil:

```
llistxattr("/nix/store/nk6b2ckznjic5wj8ddw0wgdrn4mbz3lg-patch-registry-deps", NULL, 0) = 23
llistxattr("/nix/store/nk6b2ckznjic5wj8ddw0wgdrn4mbz3lg-patch-registry-deps", "", 23) = 0
```

In this case the file being queried has a 'trusted.x' attribute associated, which explains the 'size = 23' return in 1). However, the process generating the syscalls isn't holding the CAP_SYS_ADMIN capability, which explains the 'size = 0' returned in 2).

Prior to this patch Sysbox could potentially write state into the user process' address-space based on 1)'s results. The fix is to allow this to happen only when there's actual state to write as per 2)'s outcome.

As an optimization to avoid Sysbox needing to filter the xattrs to account for processes' capabilities, sysbox-fs now makes some adjustments to allow kernel's response to be the expected one.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>