### PR TITLE
Fix for issue preventing read() operations from succeeding in a couple of procfs nodes

### DIFF
--- a/handler/implementations/utils.go
+++ b/handler/implementations/utils.go
@@ -99,8 +99,8 @@ func readFileString(
 			return 0, err
 		}
 
-		cntr.SetData(path, name, data)
 		data = val
+		cntr.SetData(path, name, data)
 	}
 
 	cntr.Unlock()


### PR DESCRIPTION
Read() only returns the expected value during its first invocation due to a bug in the 'caching' logic.

```
admin@test-1:~$ sudo cat /proc/sys/kernel/domainname
(none)

admin@test-1:~$ sudo cat /proc/sys/kernel/domainname

admin@test-1:~$ sudo cat /proc/sys/kernel/domainname

admin@test-1:~$
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>