### PR TITLE
Remove unnecessary request offset check in sysbox-fs fuse handlers.

### DIFF
--- a/handler/implementations/proc.go
+++ b/handler/implementations/proc.go
@@ -111,8 +111,8 @@ func (h *Proc) Open(
 		return nil
 
 	case "swaps", "uptime":
-               if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
-                  flags&syscall.O_RDWR == syscall.O_RDWR {
+		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
+			flags&syscall.O_RDWR == syscall.O_RDWR {
 			return fuse.IOerror{Code: syscall.EACCES}
 		}
 	}
@@ -128,12 +128,6 @@ func (h *Proc) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "swaps":

--- a/handler/implementations/procSysFs.go
+++ b/handler/implementations/procSysFs.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -135,12 +134,6 @@ func (h *ProcSysFs) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "file-max":

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -357,12 +356,6 @@ func (h *ProcSysKernel) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "cap_last_cap":

--- a/handler/implementations/procSysKernelYamaPtrace.go
+++ b/handler/implementations/procSysKernelYamaPtrace.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -157,12 +156,6 @@ func (h *ProcSysKernelYama) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single integer element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "ptrace_scope":

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,12 +132,6 @@ func (h *ProcSysNetCore) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "default_qdisc":

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -131,12 +130,6 @@ func (h *ProcSysNetIpv4Vs) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "conntrack":

--- a/handler/implementations/procSysNetNetfilter.go
+++ b/handler/implementations/procSysNetNetfilter.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -145,12 +144,6 @@ func (h *ProcSysNetNetfilter) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "nf_conntrack_max":

--- a/handler/implementations/procSysNetUnix.go
+++ b/handler/implementations/procSysNetUnix.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -105,12 +104,6 @@ func (h *ProcSysNetUnix) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "max_dgram_qlen":

--- a/handler/implementations/procSysVm.go
+++ b/handler/implementations/procSysVm.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -137,12 +136,6 @@ func (h *ProcSysVm) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	switch resource {
 	case "overcommit_memory":

--- a/handler/implementations/sysModuleNfconntrackParameters.go
+++ b/handler/implementations/sysModuleNfconntrackParameters.go
@@ -17,7 +17,6 @@
 package implementations
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -94,12 +93,6 @@ func (h *SysModuleNfconntrackParameters) Read(
 
 	logrus.Debugf("Executing Read() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
-
-	// We are dealing with a single boolean element being read, so we can save
-	// some cycles by returning right away if offset is any higher than zero.
-	if req.Offset > 0 {
-		return 0, io.EOF
-	}
 
 	return readCntrData(h, n, req)
 }


### PR DESCRIPTION
The checks being removed are no longer necessary because the readCntrData()
and writeCntrData() functions can deal with request offsets correctly.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>