### PR TITLE
Don't exit on FUSE mount errors.

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -129,7 +129,7 @@ func (s *fuseServer) Run() error {
 		fuse.DefaultPermissions(),
 	)
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Error(err)
 		return err
 	}
 


### PR DESCRIPTION
Sysbox-fs had a bug where it was exiting on FUSE mount errors.

This caused sysbox-fs to suddenly stop operating in a user's environment when
such an error was detected.

This change corrects this.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>