### PR TITLE
Serialize processing of seccomp notif per thread.

### DIFF
--- a/seccomp/pidTracker.go
+++ b/seccomp/pidTracker.go
@@ -1,0 +1,106 @@
+//
+// Copyright 2019-2022 Nestybox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package seccomp
+
+import (
+	"sync"
+)
+
+// The seccompNotifPidTracker helps serialize the processing of seccomp
+// notifications per thread, so that only one seccomp notif is processed per
+// thread-id (pid) at any given time.
+
+type seccompNotifPidTracker struct {
+	mu       sync.RWMutex
+	pidTable map[uint32]*pidData
+}
+
+type pidData struct {
+	refcnt int
+	mu     sync.Mutex
+}
+
+func newSeccompNotifPidTracker() *seccompNotifPidTracker {
+	return &seccompNotifPidTracker{
+		pidTable: make(map[uint32]*pidData),
+	}
+}
+
+// Adds the given pid to the tracker's table of tracked pids.
+func (t *seccompNotifPidTracker) track(pid uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// If pid not present in pidTable, add entry with count = 1; else increase
+	// the pid's refcount.
+	pd, ok := t.pidTable[pid]
+	if !ok {
+		t.pidTable[pid] = &pidData{refcnt: 1}
+	} else {
+		pd.refcnt++
+		t.pidTable[pid] = pd
+	}
+}
+
+// Removes the given pid from the tracker's table of tracked pids.
+func (t *seccompNotifPidTracker) untrack(pid uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	pd, ok := t.pidTable[pid]
+	if !ok {
+		return
+	}
+
+	pd.refcnt--
+
+	if pd.refcnt > 0 {
+		t.pidTable[pid] = pd
+	} else {
+		delete(t.pidTable, pid)
+	}
+}
+
+// Requests a lock on the given pid. Blocks if another process has the lock.
+func (t *seccompNotifPidTracker) Lock(pid uint32) {
+	t.track(pid)
+
+	t.mu.RLock()
+	pd, ok := t.pidTable[pid]
+	t.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	// Grab the per-pid lock
+	pd.mu.Lock()
+}
+
+// Releases the lock on the given pid. Must be called after Lock().
+func (t *seccompNotifPidTracker) Unlock(pid uint32) {
+	t.mu.RLock()
+	pd, ok := t.pidTable[pid]
+	t.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	// Release the per-pid lock
+	pd.mu.Unlock()
+
+	t.untrack(pid)
+}


### PR DESCRIPTION
The sysbox-fs seccomp notification tracer (used for syscall interception) was
recently improved to parallelize processing of all received seccomp
notifications (i.e., all trapped syscalls).

This however created a problem in which sysbox-fs would receive duplicate
notifications from the kernel for a given trapped system call. It's not clear
when the kernel does this, but our debugging shows it clearly occurs.

This in turn caused sysbox-fs to disptch goroutines to process the same trapped
syscall in parallel, which then resulted in errors sent to the process that
invoked the syscall, causing it to fail. For example, doing several consecutive
"docker pulls" inside a sysbox container would sometimes fail with "failed to
register layer: error creating overlay mount to
/var/lib/docker/overlay2/<uuid>/merged: no such file or directory".

To solve this problem without affecting performance, this commit causes
sysbox-fs to serialize seccomp notif processing per kernel thread (i.e., per
seccomp notif pid). This ensures that sysbox-fs will never process two seccomp
notifs for the same thread in parallel, even if the kernel issues such
notifications. Note that this does not affect performance because threads can
only issue syscall at a time, so serializing seccomp notifs per thread on
sysbox-fs does not slow down things (except for the very small overhead of the
serialization code, which uses a golang map track pids and look them up
quickly).

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>