### PR TITLE
Fix nsenter agent process credentials in getxattr and listxattr syscall handlers.

### DIFF
--- a/seccomp/xattr.go
+++ b/seccomp/xattr.go
@@ -216,11 +216,11 @@ func (si *getxattrSyscallInfo) processGetxattr() (*sysResponse, error) {
 	// Perform the nsenter into the process namespaces (except the user-ns)
 	payload := domain.GetxattrSyscallPayload{
 		Header: domain.NSenterMsgHeader{
-			Pid:          si.pid,
-			Uid:          si.uid,
-			Gid:          si.gid,
-			Root:         si.root,
-			Cwd:          si.cwd,
+			Pid:          process.Pid(),
+			Uid:          process.Uid(),
+			Gid:          process.Gid(),
+			Root:         process.Root(),
+			Cwd:          process.Cwd(),
 			Capabilities: process.GetEffCaps(),
 		},
 		Syscall: si.syscallName,
@@ -371,11 +371,11 @@ func (si *listxattrSyscallInfo) processListxattr() (*sysResponse, error) {
 	// Perform the nsenter into the process namespaces (except the user-ns)
 	payload := domain.ListxattrSyscallPayload{
 		Header: domain.NSenterMsgHeader{
-			Pid:          si.pid,
-			Uid:          si.uid,
-			Gid:          si.gid,
-			Root:         si.root,
-			Cwd:          si.cwd,
+			Pid:          process.Pid(),
+			Uid:          process.Uid(),
+			Gid:          process.Gid(),
+			Root:         process.Root(),
+			Cwd:          process.Cwd(),
 			Capabilities: process.GetEffCaps(),
 		},
 		Syscall: si.syscallName,


### PR DESCRIPTION
The sysbox-fs syscall handler for getxattr and listxattr was not properly
adjusting the nsenter agent process credentials to match those of the process
that made the syscall (it was only adjusting the capabilities, but not the
uid/gid). As a result, it was getting EPERM errors when trying to access a path
in the container which was only accessible by the process that made the syscall.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>