### PR TITLE
Adjust sysDevicesVirtual handler to prevent systemd timeouts.

### DIFF
--- a/handler/implementations/sysDevicesVirtual.go
+++ b/handler/implementations/sysDevicesVirtual.go
@@ -104,7 +104,16 @@ func (h *SysDevicesVirtual) Lookup(
 		return info, nil
 	}
 
-	return h.Service.GetPassThroughHandler().Lookup(n, req)
+	// XXX: for non emulated resources under /sys/devices/virtual, we should
+	// ideally request the passthrough handler to perform the lookup; however
+	// this slows down the lookup and causes sysbox containers with systemd
+	// inside to fail in hosts with kernel < 5.19 (i.e., systemd takes too long
+	// to boot because for some reason it's doing lots of lookups of
+	// /sys/virtual/devices/block/loopX devices, causing it to timeout).  Instead
+	// we do the lookup at host level, which is perfectly fine except since we
+	// don't know of any files under /sys/virtual/devices which Linux exposes at
+	// host level but not inside containers.
+	return n.Stat()
 }
 
 func (h *SysDevicesVirtual) Open(


### PR DESCRIPTION
In the lookup method of the sysDevicesVirtual handler, for non-emulated resources under /sys/devices/virtual, we should ideally request the passthrough handler to perform lookup.

However this slows down the lookup and causes sysbox containers with systemd inside to fail in hosts with kernel < 5.19 (i.e., systemd takes too long to boot because for some reason it's doing lots of lookups of /sys/virtual/devices/block/loopX devices, causing it to timeout).

To fix this, do the lookup at host level, which is faster since it avoids entering the container's namespaces. This is fine since we don't know of any files under /sys/virtual/devices which Linux exposes at host level but not inside containers.