### PR TITLE
Extend Sysbox emulation logic to support symlink nodes

### DIFF
--- a/domain/handler.go
+++ b/domain/handler.go
@@ -100,6 +100,7 @@ type HandlerIface interface {
 	Read(node IOnodeIface, req *HandlerRequest) (int, error)
 	Write(node IOnodeIface, req *HandlerRequest) (int, error)
 	ReadDirAll(node IOnodeIface, req *HandlerRequest) ([]os.FileInfo, error)
+	ReadLink(node IOnodeIface, req *HandlerRequest) (string, error)
 
 	// getters/setters.
 	GetName() string

--- a/domain/ionode.go
+++ b/domain/ionode.go
@@ -56,11 +56,13 @@ type IOnodeIface interface {
 	ReadDirAll() ([]os.FileInfo, error)
 	ReadFile() ([]byte, error)
 	ReadLine() (string, error)
+	ReadLink() (string, error)
 	WriteAt(p []byte, off int64) (n int, err error)
 	WriteFile(p []byte) error
 	Mkdir() error
 	MkdirAll() error
 	Stat() (os.FileInfo, error)
+	Lstat() (os.FileInfo, error)
 	SeekReset() (int64, error)
 	Remove() error
 	RemoveAll() error

--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ const (
 	WriteFileResponse          NSenterMsgType = "writeFileResponse"
 	ReadDirRequest             NSenterMsgType = "readDirRequest"
 	ReadDirResponse            NSenterMsgType = "readDirResponse"
+	ReadLinkRequest            NSenterMsgType = "readLinkRequest"
+	ReadLinkResponse           NSenterMsgType = "readLinkResponse"
 	MountSyscallRequest        NSenterMsgType = "mountSyscallRequest"
 	MountSyscallResponse       NSenterMsgType = "mountSyscallResponse"
 	UmountSyscallRequest       NSenterMsgType = "umountSyscallRequest"
@@ -190,6 +192,12 @@ type WriteFilePayload struct {
 
 type ReadDirPayload struct {
 	Dir         string `json:"dir"`
+	MountSysfs  bool   `json:mountSysfs`
+	MountProcfs bool   `json:mountProcfs`
+}
+
+type ReadLinkPayload struct {
+	Link        string `json:"link"`
 	MountSysfs  bool   `json:mountSysfs`
 	MountProcfs bool   `json:mountProcfs`
 }

--- a/handler/implementations/passThrough_test.go
+++ b/handler/implementations/passThrough_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/handler/implementations/procSwaps.go
+++ b/handler/implementations/procSwaps.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,6 +114,16 @@ func (h *ProcSwaps) ReadDirAll(
 		req.ID, h.Name, resource)
 
 	return nil, nil
+}
+
+func (h *ProcSwaps) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return "", nil
 }
 
 func (h *ProcSwaps) GetName() string {

--- a/handler/implementations/procSys.go
+++ b/handler/implementations/procSys.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2022 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,6 +125,16 @@ func (h *ProcSys) ReadDirAll(
 		req.ID, h.Name, n.Name())
 
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSys) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSys) GetName() string {

--- a/handler/implementations/procSysFs.go
+++ b/handler/implementations/procSysFs.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,6 +195,16 @@ func (h *ProcSysFs) ReadDirAll(
 
 	// Return all entries as seen within container's namespaces.
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSysFs) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysFs) GetName() string {

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -495,6 +495,16 @@ func (h *ProcSysKernel) ReadDirAll(
 
 	// Return all entries as seen within container's namespaces.
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSysKernel) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysKernel) GetName() string {

--- a/handler/implementations/procSysKernelYamaPtrace.go
+++ b/handler/implementations/procSysKernelYamaPtrace.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,6 +196,16 @@ func (h *ProcSysKernelYama) ReadDirAll(
 
 	// Return all entries as seen within container's namespaces.
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSysKernelYama) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysKernelYama) GetName() string {

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import (
 	"github.com/nestybox/sysbox-fs/fuse"
 )
 
-//
 // /proc/sys/net/core handler
 //
 // Emulated resources:
@@ -51,11 +50,11 @@ import (
 //
 // Supported schedulers (https://github.com/torvalds/linux/blob/master/net/sched/Kconfig#L478):
 //
-// 	- "pfifo_fast"
-//	- "fq"
-//	- "fq_codel"
-//	- "sfq"
-//	- "pfifo_fast"
+//   - "pfifo_fast"
+//   - "fq"
+//   - "fq_codel"
+//   - "sfq"
+//   - "pfifo_fast"
 //
 // As this is a system-wide attribute with mutually-exclusive values, changes
 // will be only made superficially (at sys-container level). IOW, the host FS
@@ -66,7 +65,6 @@ import (
 // Description: Limit of socket listen() backlog, known in userspace as SOMAXCONN.
 // Somaxconn refers to the maximum number of clients that the server can accept
 // to process data, that is, to complete the connection limit. Defaults to 128.
-//
 type ProcSysNetCore struct {
 	domain.HandlerBase
 }
@@ -198,6 +196,16 @@ func (h *ProcSysNetCore) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *ProcSysNetCore) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysNetCore) GetName() string {

--- a/handler/implementations/procSysNetIpv4.go
+++ b/handler/implementations/procSysNetIpv4.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,13 +34,11 @@ import (
 	"github.com/nestybox/sysbox-runc/libcontainer/user"
 )
 
-//
 // /proc/sys/net/ipv4 handler
 //
 // Emulated resources:
 //
 // * /proc/sys/net/ipv4/ping_group_range
-//
 type ProcSysNetIpv4 struct {
 	domain.HandlerBase
 }
@@ -120,6 +118,16 @@ func (h *ProcSysNetIpv4) ReadDirAll(
 
 	// Return all entries as seen within container's namespaces.
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSysNetIpv4) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysNetIpv4) GetName() string {

--- a/handler/implementations/procSysNetIpv4Neigh.go
+++ b/handler/implementations/procSysNetIpv4Neigh.go
@@ -256,6 +256,16 @@ func (h *ProcSysNetIpv4Neigh) ReadDirAll(
 	return fileEntries, nil
 }
 
+func (h *ProcSysNetIpv4Neigh) ReadLink(
+        n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+        logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+	        req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
+}
+
 func (h *ProcSysNetIpv4Neigh) GetName() string {
 	return h.Name
 }

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,6 +215,16 @@ func (h *ProcSysNetIpv4Vs) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *ProcSysNetIpv4Vs) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysNetIpv4Vs) GetName() string {

--- a/handler/implementations/procSysNetNetfilter.go
+++ b/handler/implementations/procSysNetNetfilter.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -235,6 +235,16 @@ func (h *ProcSysNetNetfilter) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *ProcSysNetNetfilter) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysNetNetfilter) GetName() string {

--- a/handler/implementations/procSysNetUnix.go
+++ b/handler/implementations/procSysNetUnix.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,13 +27,11 @@ import (
 	"github.com/nestybox/sysbox-fs/domain"
 )
 
-//
 // /proc/sys/net/unix handler
 //
 // Emulated resources:
 //
 // * /proc/sys/net/unix/max_dgram_qlen
-//
 type ProcSysNetUnix struct {
 	domain.HandlerBase
 }
@@ -171,6 +169,16 @@ func (h *ProcSysNetUnix) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *ProcSysNetUnix) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysNetUnix) GetName() string {

--- a/handler/implementations/procSysVm.go
+++ b/handler/implementations/procSysVm.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,6 +195,16 @@ func (h *ProcSysVm) ReadDirAll(
 
 	// Return all entries as seen within container's namespaces.
 	return h.Service.GetPassThroughHandler().ReadDirAll(n, req)
+}
+
+func (h *ProcSysVm) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }
 
 func (h *ProcSysVm) GetName() string {

--- a/handler/implementations/procUptime.go
+++ b/handler/implementations/procUptime.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,6 +113,16 @@ func (h *ProcUptime) ReadDirAll(
 		req.ID, h.Name, resource)
 
 	return nil, nil
+}
+
+func (h *ProcUptime) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return "", nil
 }
 
 func (h *ProcUptime) GetName() string {

--- a/handler/implementations/root.go
+++ b/handler/implementations/root.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ func (h *Root) Lookup(
 	logrus.Debugf("Executing Lookup() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, resource)
 
-	return n.Stat()
+	return n.Lstat()
 }
 
 func (h *Root) Open(
@@ -95,6 +95,16 @@ func (h *Root) ReadDirAll(
 		req.ID, h.Name, resource)
 
 	return nil, nil
+}
+
+func (h *Root) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return "", nil
 }
 
 func (h *Root) GetName() string {

--- a/handler/implementations/sysDevicesVirtualDmi.go
+++ b/handler/implementations/sysDevicesVirtualDmi.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2022 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ func (h *SysDevicesVirtualDmi) Lookup(
 		return info, nil
 	}
 
-	return n.Stat()
+	return n.Lstat()
 }
 
 func (h *SysDevicesVirtualDmi) Open(
@@ -199,6 +199,16 @@ func (h *SysDevicesVirtualDmi) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *SysDevicesVirtualDmi) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return n.ReadLink()
 }
 
 func (h *SysDevicesVirtualDmi) GetName() string {

--- a/handler/implementations/sysDevicesVirtualDmiId.go
+++ b/handler/implementations/sysDevicesVirtualDmiId.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2022 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ func (h *SysDevicesVirtualDmiId) Lookup(
 	// Skip uid/gid remaps for all other (non-emulated) resources.
 	req.SkipIdRemap = true
 
-	return n.Stat()
+	return n.Lstat()
 }
 
 func (h *SysDevicesVirtualDmiId) Open(
@@ -273,6 +273,16 @@ func (h *SysDevicesVirtualDmiId) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *SysDevicesVirtualDmiId) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return n.ReadLink()
 }
 
 func (h *SysDevicesVirtualDmiId) GetName() string {

--- a/handler/implementations/sysDevicesVirtualDmiId_test.go
+++ b/handler/implementations/sysDevicesVirtualDmiId_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/handler/implementations/sysKernel.go
+++ b/handler/implementations/sysKernel.go
@@ -123,7 +123,7 @@ func (h *SysKernel) Lookup(
 	// gid=0).
 	req.SkipIdRemap = true
 
-	return n.Stat()
+	return n.Lstat()
 }
 
 func (h *SysKernel) Open(
@@ -237,6 +237,16 @@ func (h *SysKernel) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *SysKernel) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return n.ReadLink()
 }
 
 func (h *SysKernel) GetName() string {

--- a/handler/implementations/sysModuleNfconntrackParameters.go
+++ b/handler/implementations/sysModuleNfconntrackParameters.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2020 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ func (h *SysModuleNfconntrackParameters) Lookup(
 	// Users should not be allowed to alter any of the non-emulated sysfs nodes.
 	req.SkipIdRemap = true
 
-	return n.Stat()
+	return n.Lstat()
 }
 
 func (h *SysModuleNfconntrackParameters) Open(
@@ -188,6 +188,16 @@ func (h *SysModuleNfconntrackParameters) ReadDirAll(
 	}
 
 	return fileEntries, nil
+}
+
+func (h *SysModuleNfconntrackParameters) ReadLink(
+	n domain.IOnodeIface,
+	req *domain.HandlerRequest) (string, error) {
+
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
+
+	return n.ReadLink()
 }
 
 func (h *SysModuleNfconntrackParameters) GetName() string {

--- a/handler/implementations/utils.go
+++ b/handler/implementations/utils.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021 Nestybox, Inc.
+// Copyright 2019-2023 Nestybox, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sysio/ionodeFile.go
+++ b/sysio/ionodeFile.go
@@ -34,9 +34,7 @@ import (
 var _ domain.IOServiceIface = (*ioFileService)(nil)
 var _ domain.IOnodeIface = (*IOnodeFile)(nil)
 
-//
 // I/O Service providing FS interaction capabilities.
-//
 type ioFileService struct {
 	fsType domain.IOServiceType
 	appFs  afero.Fs
@@ -85,9 +83,7 @@ func (i *ioFileService) GetServiceType() domain.IOServiceType {
 	return i.fsType
 }
 
-//
 // IOnode class specialization for FS interaction.
-//
 type IOnodeFile struct {
 	name  string
 	path  string
@@ -201,6 +197,10 @@ func (i *IOnodeFile) ReadLine() (string, error) {
 	return res, nil
 }
 
+func (i *IOnodeFile) ReadLink() (string, error) {
+	return os.Readlink(i.path)
+}
+
 func (i *IOnodeFile) WriteAt(p []byte, off int64) (n int, err error) {
 
 	if i.file == nil {
@@ -265,6 +265,10 @@ func (i *IOnodeFile) GetNsInode() (domain.Inode, error) {
 
 func (i *IOnodeFile) Stat() (os.FileInfo, error) {
 	return i.fss.appFs.Stat(i.path)
+}
+
+func (i *IOnodeFile) Lstat() (os.FileInfo, error) {
+	return os.Lstat(i.path)
 }
 
 func (i *IOnodeFile) SeekReset() (int64, error) {


### PR DESCRIPTION
Prior to this commit, Sysbox did not properly handle symlinks present in the procfs/sysfs node hierarchies. For example, the softlink represented by the `/sys/devices/virtual/dmi/id/subsystem` is not properly displayed as the stat() operation collects information only associated with the softlink 'target' and not the link itself:

```
root@d341ddabdc98:/# stat /sys/devices/virtual/dmi/id/subsystem
  File: /sys/devices/virtual/dmi/id/subsystem
  Size: 0         	Blocks: 0          IO Block: 4096   directory
Device: 3ah/58d	Inode: 1805        Links: 2
Access: (0755/drwxr-xr-x)  Uid: (65534/  nobody)   Gid: (65534/ nogroup)
Access: 2023-11-26 21:33:23.284019025 +0000
Modify: 2023-11-10 19:53:57.276000000 +0000
Change: 2023-11-10 19:53:57.276000000 +0000
 Birth: -
root@d341ddabdc98:/#
````

Problem can be fixed by replacing the stat() file-operation by the lstat() one, and by expanding Sysbox handlers to incorporate the readlink() file-operation (which is automatically called by libc/vfs upon detection of symlink fileInfo.Mode during lookup()/getattr() calls).

```
root@8a57bbb0b76e:/# stat /sys/devices/virtual/dmi/id/subsystem
  File: /sys/devices/virtual/dmi/id/subsystem -> ../../../../class/dmi
  Size: 0         	Blocks: 0          IO Block: 4096   symbolic link
Device: 3ah/58d	Inode: 1809        Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (65534/  nobody)   Gid: (65534/ nogroup)
Access: 2023-11-26 21:32:15.607983621 +0000
Modify: 2023-11-10 19:53:57.276000000 +0000
Change: 2023-11-10 19:53:57.276000000 +0000
 Birth: -
```

The problem above was causing endless loops in applications attempting to walk() the `/sys` file-system hierarchy, as Sysbox was not reporting the softlink as it should:

```
 => [harmonia harmonia-build 1/1] RUN --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/root/.cache/go-out,id=go-out-arm64     --mo  130.0s
 => => # find: /sys/devices/virtual/bdi/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/
 => => # subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:54/subsystem/43:320/subsystem/7:6/subsystem: No such file or directory
 => => # find: /sys/devices/virtual/bdi/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/
 => => # subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:54/subsystem/43:320/subsystem/7:7/subsystem: No such file or directory
 => => # find: /sys/devices/virtual/bdi/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsystem/0:44/subsys
 => => # [output clipped, log limit 2MiB reached]
```