### PR TITLE
Fixes for /proc emulation for kernel 6.5+.

### DIFF
--- a/domain/handler.go
+++ b/domain/handler.go
@@ -95,7 +95,7 @@ type HandlerRequest struct {
 // HandlerIface is the interface that each handler must implement
 type HandlerIface interface {
 	// FS operations.
-	Open(node IOnodeIface, req *HandlerRequest) error
+	Open(node IOnodeIface, req *HandlerRequest) (bool, error)
 	Lookup(n IOnodeIface, req *HandlerRequest) (os.FileInfo, error)
 	Read(node IOnodeIface, req *HandlerRequest) (int, error)
 	Write(node IOnodeIface, req *HandlerRequest) (int, error)

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -239,12 +239,16 @@ func (d *Dir) Create(
 
 	// Handler execution. 'Open' handler will create new element if requesting
 	// process has the proper credentials / capabilities.
-	err := handler.Open(ionode, handlerReq)
+	nonSeekable, err := handler.Open(ionode, handlerReq)
 	if err != nil && err != io.EOF {
 		logrus.Debugf("Open() error: %v", err)
 		return nil, nil, err
 	}
+
 	resp.Flags |= fuse.OpenDirectIO
+	if nonSeekable {
+		resp.Flags |= fuse.OpenNonSeekable
+	}
 
 	// To satisfy Bazil FUSE lib we are expected to return a lookup-response
 	// and an open-response, let's start with the lookup() one.

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -103,6 +103,8 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
 		a.Valid = time.Duration(AttribCacheTimeout)
 	}
 
+	logrus.Debugf("Attr() operation for entry %v: %+v", f.path, *a)
+
 	return nil
 }
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -142,7 +142,7 @@ func (f *File) Open(
 	}
 
 	// Handler execution.
-	err := handler.Open(ionode, handlerReq)
+	nonSeekable, err := handler.Open(ionode, handlerReq)
 	if err != nil && err != io.EOF {
 		logrus.Debugf("Open() error: %v", err)
 		return nil, err
@@ -163,6 +163,10 @@ func (f *File) Open(
 	// pose a problem for Sysbox as we are dealing with special FSs.
 	//
 	resp.Flags |= fuse.OpenDirectIO
+
+	if nonSeekable {
+		resp.Flags |= fuse.OpenNonSeekable
+	}
 
 	return f, nil
 }

--- a/handler/implementations/passThrough.go
+++ b/handler/implementations/passThrough.go
@@ -116,7 +116,7 @@ func (h *PassThrough) Lookup(
 
 func (h *PassThrough) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
@@ -146,16 +146,16 @@ func (h *PassThrough) Open(
 	// Launch nsenter-event.
 	err := nss.SendRequestEvent(event)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Obtain nsenter-event response.
 	responseMsg := nss.ReceiveResponseEvent(event)
 	if responseMsg.Type == domain.ErrorResponse {
-		return responseMsg.Payload.(error)
+		return false, responseMsg.Payload.(error)
 	}
 
-	return nil
+	return false, nil
 }
 
 func (h *PassThrough) Read(

--- a/handler/implementations/procSwaps.go
+++ b/handler/implementations/procSwaps.go
@@ -62,6 +62,7 @@ func (h *ProcSwaps) Lookup(
 		Fname:    resource,
 		Fmode:    os.FileMode(uint32(0444)),
 		FmodTime: time.Now(),
+		Fsize:    4096,
 	}
 
 	return info, nil

--- a/handler/implementations/procSwaps.go
+++ b/handler/implementations/procSwaps.go
@@ -70,7 +70,7 @@ func (h *ProcSwaps) Lookup(
 
 func (h *ProcSwaps) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
@@ -79,10 +79,10 @@ func (h *ProcSwaps) Open(
 
 	if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
 		flags&syscall.O_RDWR == syscall.O_RDWR {
-		return fuse.IOerror{Code: syscall.EACCES}
+		return false, fuse.IOerror{Code: syscall.EACCES}
 	}
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSwaps) Read(

--- a/handler/implementations/procSys.go
+++ b/handler/implementations/procSys.go
@@ -89,7 +89,7 @@ func (h *ProcSys) Lookup(
 
 func (h *ProcSys) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())

--- a/handler/implementations/procSysFs.go
+++ b/handler/implementations/procSysFs.go
@@ -117,7 +117,7 @@ func (h *ProcSysFs) Lookup(
 
 func (h *ProcSysFs) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -126,16 +126,16 @@ func (h *ProcSysFs) Open(
 
 	switch resource {
 	case "file-max":
-		return nil
+		return false, nil
 
 	case "nr_open":
-		return nil
+		return false, nil
 
 	case "protected_hardlinks":
-		return nil
+		return false, nil
 
 	case "protected_symlinks":
-		return nil
+		return false, nil
 	}
 
 	return h.Service.GetPassThroughHandler().Open(n, req)

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -236,56 +236,67 @@ var ProcSysKernel_Handler = &ProcSysKernel{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    4096,
 			},
 			"hostname": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    4096,
 			},
 			"kptr_restrict": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"dmesg_restrict": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"ngroups_max": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0444)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"cap_last_cap": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0444)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"panic": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    4096,
 			},
 			"panic_on_oops": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"printk": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"sysrq": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"pid_max": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -307,6 +318,7 @@ func (h *ProcSysKernel) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -331,7 +331,7 @@ func (h *ProcSysKernel) Lookup(
 
 func (h *ProcSysKernel) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -344,43 +344,43 @@ func (h *ProcSysKernel) Open(
 	case "cap_last_cap":
 		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
 			flags&syscall.O_RDWR == syscall.O_RDWR {
-			return fuse.IOerror{Code: syscall.EACCES}
+			return false, fuse.IOerror{Code: syscall.EACCES}
 		}
-		return nil
+		return false, nil
 
 	case "pid_max":
-		return nil
+		return false, nil
 
 	case "ngroups_max":
 		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
 			flags&syscall.O_RDWR == syscall.O_RDWR {
-			return fuse.IOerror{Code: syscall.EACCES}
+			return false, fuse.IOerror{Code: syscall.EACCES}
 		}
-		return nil
+		return false, nil
 
 	case "domainname":
-		return nil
+		return false, nil
 
 	case "hostname":
-		return nil
+		return false, nil
 
 	case "kptr_restrict":
-		return nil
+		return false, nil
 
 	case "dmesg_restrict":
-		return nil
+		return false, nil
 
 	case "panic":
-		return nil
+		return false, nil
 
 	case "panic_on_oops":
-		return nil
+		return false, nil
 
 	case "sysrq":
-		return nil
+		return false, nil
 
 	case "printk":
-		return nil
+		return false, nil
 	}
 
 	// Refer to generic handler if no node match is found above.

--- a/handler/implementations/procSysKernelYamaPtrace.go
+++ b/handler/implementations/procSysKernelYamaPtrace.go
@@ -110,6 +110,7 @@ var ProcSysKernelYama_Handler = &ProcSysKernelYama{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2, // value + newline
 			},
 		},
 	},
@@ -131,6 +132,7 @@ func (h *ProcSysKernelYama) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysKernelYamaPtrace.go
+++ b/handler/implementations/procSysKernelYamaPtrace.go
@@ -145,9 +145,9 @@ func (h *ProcSysKernelYama) Lookup(
 
 func (h *ProcSysKernelYama) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysKernelYama) Read(

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -195,6 +195,8 @@ func (h *ProcSysNetCore) ReadDirAll(
 		fileEntries = append(fileEntries, usualEntries...)
 	}
 
+	fileEntries = domain.FileInfoSliceUniquify(fileEntries)
+
 	return fileEntries, nil
 }
 

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -79,11 +79,13 @@ var ProcSysNetCore_Handler = &ProcSysNetCore{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"somaxconn": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -105,6 +107,7 @@ func (h *ProcSysNetCore) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysNetCore.go
+++ b/handler/implementations/procSysNetCore.go
@@ -120,12 +120,12 @@ func (h *ProcSysNetCore) Lookup(
 
 func (h *ProcSysNetCore) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysNetCore) Read(

--- a/handler/implementations/procSysNetIpv4.go
+++ b/handler/implementations/procSysNetIpv4.go
@@ -88,9 +88,9 @@ func (h *ProcSysNetIpv4) Lookup(
 
 func (h *ProcSysNetIpv4) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysNetIpv4) Read(

--- a/handler/implementations/procSysNetIpv4Neigh.go
+++ b/handler/implementations/procSysNetIpv4Neigh.go
@@ -37,10 +37,9 @@ import (
 // Emulated resources:
 //
 // * /proc/sys/net/ipv4/default/gc_thresh1
-//
 // * /proc/sys/net/ipv4/default/gc_thresh2
-//
 // * /proc/sys/net/ipv4/default/gc_thresh3
+
 type ProcSysNetIpv4Neigh struct {
 	domain.HandlerBase
 }
@@ -60,16 +59,19 @@ var ProcSysNetIpv4Neigh_Handler = &ProcSysNetIpv4Neigh{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"default/gc_thresh2": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"default/gc_thresh3": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -103,6 +105,7 @@ func (h *ProcSysNetIpv4Neigh) Lookup(
 		info := &domain.FileInfo{
 			Fname:    resource,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		if v.Kind == domain.DirEmuResource {

--- a/handler/implementations/procSysNetIpv4Neigh.go
+++ b/handler/implementations/procSysNetIpv4Neigh.go
@@ -32,7 +32,6 @@ import (
 	"github.com/nestybox/sysbox-fs/fuse"
 )
 
-//
 // /proc/sys/net/ipv4/neigh handler
 //
 // Emulated resources:
@@ -42,7 +41,6 @@ import (
 // * /proc/sys/net/ipv4/default/gc_thresh2
 //
 // * /proc/sys/net/ipv4/default/gc_thresh3
-//
 type ProcSysNetIpv4Neigh struct {
 	domain.HandlerBase
 }
@@ -253,15 +251,17 @@ func (h *ProcSysNetIpv4Neigh) ReadDirAll(
 		fileEntries = append(fileEntries, usualEntries...)
 	}
 
+	fileEntries = domain.FileInfoSliceUniquify(fileEntries)
+
 	return fileEntries, nil
 }
 
 func (h *ProcSysNetIpv4Neigh) ReadLink(
-        n domain.IOnodeIface,
+	n domain.IOnodeIface,
 	req *domain.HandlerRequest) (string, error) {
 
-        logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
-	        req.ID, h.Name, n.Name())
+	logrus.Debugf("Executing ReadLink() for req-id: %#x, handler: %s, resource: %s",
+		req.ID, h.Name, n.Name())
 
 	return h.Service.GetPassThroughHandler().ReadLink(n, req)
 }

--- a/handler/implementations/procSysNetIpv4Neigh.go
+++ b/handler/implementations/procSysNetIpv4Neigh.go
@@ -125,9 +125,9 @@ func (h *ProcSysNetIpv4Neigh) Lookup(
 
 func (h *ProcSysNetIpv4Neigh) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysNetIpv4Neigh) Read(

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -45,9 +45,7 @@ import (
 // Emulated resources:
 //
 // * /proc/sys/net/ipv4/vs/conn_reuse_mode handler
-//
 // * /proc/sys/net/ipv4/vs/expire_nodest_conn handler
-//
 // * /proc/sys/net/ipv4/vs/expire_quiescent_template handler
 //
 
@@ -70,21 +68,25 @@ var ProcSysNetIpv4Vs_Handler = &ProcSysNetIpv4Vs{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"conn_reuse_mode": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"expire_nodest_conn": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"expire_quiescent_template": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 		},
 	},
@@ -106,6 +108,7 @@ func (h *ProcSysNetIpv4Vs) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -121,9 +121,9 @@ func (h *ProcSysNetIpv4Vs) Lookup(
 
 func (h *ProcSysNetIpv4Vs) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysNetIpv4Vs) Read(

--- a/handler/implementations/procSysNetIpv4Vs.go
+++ b/handler/implementations/procSysNetIpv4Vs.go
@@ -217,6 +217,8 @@ func (h *ProcSysNetIpv4Vs) ReadDirAll(
 		fileEntries = append(fileEntries, usualEntries...)
 	}
 
+	fileEntries = domain.FileInfoSliceUniquify(fileEntries)
+
 	return fileEntries, nil
 }
 

--- a/handler/implementations/procSysNetNetfilter.go
+++ b/handler/implementations/procSysNetNetfilter.go
@@ -76,26 +76,31 @@ var ProcSysNetNetfilter_Handler = &ProcSysNetNetfilter{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"nf_conntrack_generic_timeout": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"nf_conntrack_tcp_be_liberal": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"nf_conntrack_tcp_timeout_established": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 			"nf_conntrack_tcp_timeout_close_wait": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -117,6 +122,7 @@ func (h *ProcSysNetNetfilter) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysNetNetfilter.go
+++ b/handler/implementations/procSysNetNetfilter.go
@@ -135,11 +135,11 @@ func (h *ProcSysNetNetfilter) Lookup(
 
 func (h *ProcSysNetNetfilter) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing %v Open() method\n", h.Name)
 
-	return nil
+	return false, nil
 }
 
 func (h *ProcSysNetNetfilter) Read(

--- a/handler/implementations/procSysNetNetfilter.go
+++ b/handler/implementations/procSysNetNetfilter.go
@@ -234,6 +234,8 @@ func (h *ProcSysNetNetfilter) ReadDirAll(
 		fileEntries = append(fileEntries, usualEntries...)
 	}
 
+	fileEntries = domain.FileInfoSliceUniquify(fileEntries)
+
 	return fileEntries, nil
 }
 

--- a/handler/implementations/procSysNetUnix.go
+++ b/handler/implementations/procSysNetUnix.go
@@ -82,7 +82,7 @@ func (h *ProcSysNetUnix) Lookup(
 
 func (h *ProcSysNetUnix) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -91,7 +91,7 @@ func (h *ProcSysNetUnix) Open(
 
 	switch resource {
 	case "max_dgram_qlen":
-		return nil
+		return false, nil
 	}
 
 	return h.Service.GetPassThroughHandler().Open(n, req)

--- a/handler/implementations/procSysNetUnix.go
+++ b/handler/implementations/procSysNetUnix.go
@@ -32,6 +32,7 @@ import (
 // Emulated resources:
 //
 // * /proc/sys/net/unix/max_dgram_qlen
+
 type ProcSysNetUnix struct {
 	domain.HandlerBase
 }
@@ -46,6 +47,7 @@ var ProcSysNetUnix_Handler = &ProcSysNetUnix{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -67,6 +69,7 @@ func (h *ProcSysNetUnix) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil
@@ -167,6 +170,8 @@ func (h *ProcSysNetUnix) ReadDirAll(
 	if err == nil {
 		fileEntries = append(fileEntries, usualEntries...)
 	}
+
+	fileEntries = domain.FileInfoSliceUniquify(fileEntries)
 
 	return fileEntries, nil
 }

--- a/handler/implementations/procSysVm.go
+++ b/handler/implementations/procSysVm.go
@@ -73,11 +73,13 @@ var ProcSysVm_Handler = &ProcSysVm{
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    2,
 			},
 			"mmap_min_addr": {
 				Kind:    domain.FileEmuResource,
 				Mode:    os.FileMode(uint32(0644)),
 				Enabled: true,
+				Size:    1024,
 			},
 		},
 	},
@@ -99,6 +101,7 @@ func (h *ProcSysVm) Lookup(
 			Fname:    resource,
 			Fmode:    v.Mode,
 			FmodTime: time.Now(),
+			Fsize:    v.Size,
 		}
 
 		return info, nil

--- a/handler/implementations/procSysVm.go
+++ b/handler/implementations/procSysVm.go
@@ -114,7 +114,7 @@ func (h *ProcSysVm) Lookup(
 
 func (h *ProcSysVm) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -123,10 +123,10 @@ func (h *ProcSysVm) Open(
 
 	switch resource {
 	case "overcommit_memory":
-		return nil
+		return false, nil
 
 	case "mmap_min_addr":
-		return nil
+		return false, nil
 	}
 
 	return h.Service.GetPassThroughHandler().Open(n, req)

--- a/handler/implementations/procUptime.go
+++ b/handler/implementations/procUptime.go
@@ -68,7 +68,7 @@ func (h *ProcUptime) Lookup(
 
 func (h *ProcUptime) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -79,10 +79,11 @@ func (h *ProcUptime) Open(
 
 	if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
 		flags&syscall.O_RDWR == syscall.O_RDWR {
-		return fuse.IOerror{Code: syscall.EACCES}
+		return false, fuse.IOerror{Code: syscall.EACCES}
 	}
 
-	return nil
+	// /proc/uptime is not seekable
+	return true, nil
 }
 
 func (h *ProcUptime) Read(

--- a/handler/implementations/procUptime.go
+++ b/handler/implementations/procUptime.go
@@ -60,6 +60,7 @@ func (h *ProcUptime) Lookup(
 		Fname:    resource,
 		Fmode:    os.FileMode(uint32(0444)),
 		FmodTime: time.Now(),
+		Fsize:    4096,
 	}
 
 	return info, nil
@@ -208,9 +209,9 @@ func (h *ProcUptime) readUptime(
 	//
 	uptimeDur := time.Now().Sub(data) / time.Nanosecond
 	var uptime float64 = uptimeDur.Seconds()
-	uptimeStr := fmt.Sprintf("%.2f", uptime)
+	uptimeStr := fmt.Sprintf("%.2f %.2f\n", uptime, uptime)
 
-	req.Data = []byte(uptimeStr + " " + uptimeStr + "\n")
+	req.Data = []byte(uptimeStr)
 
 	return len(req.Data), nil
 }

--- a/handler/implementations/root.go
+++ b/handler/implementations/root.go
@@ -66,9 +66,9 @@ func (h *Root) Lookup(
 
 func (h *Root) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *Root) Read(

--- a/handler/implementations/sysDevicesVirtual.go
+++ b/handler/implementations/sysDevicesVirtual.go
@@ -128,12 +128,12 @@ func (h *SysDevicesVirtual) Lookup(
 
 func (h *SysDevicesVirtual) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
 
-	return nil
+	return false, nil
 }
 
 func (h *SysDevicesVirtual) Read(

--- a/handler/implementations/sysDevicesVirtualDmi.go
+++ b/handler/implementations/sysDevicesVirtualDmi.go
@@ -116,12 +116,12 @@ func (h *SysDevicesVirtualDmi) Lookup(
 
 func (h *SysDevicesVirtualDmi) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
 
-	return nil
+	return false, nil
 }
 
 func (h *SysDevicesVirtualDmi) Read(

--- a/handler/implementations/sysDevicesVirtualDmiId.go
+++ b/handler/implementations/sysDevicesVirtualDmiId.go
@@ -159,14 +159,14 @@ func (h *SysDevicesVirtualDmiId) Lookup(
 
 func (h *SysDevicesVirtualDmiId) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	logrus.Debugf("Executing Open() for req-id: %#x, handler: %s, resource: %s",
 		req.ID, h.Name, n.Name())
 
 	relpath, err := filepath.Rel(h.Path, n.Path())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	var resource = relpath
@@ -176,17 +176,17 @@ func (h *SysDevicesVirtualDmiId) Open(
 	switch resource {
 
 	case ".":
-		return nil
+		return false, nil
 
 	case "product_uuid":
 		if flags&syscall.O_WRONLY == syscall.O_WRONLY ||
 			flags&syscall.O_RDWR == syscall.O_RDWR {
-			return fuse.IOerror{Code: syscall.EACCES}
+			return false, fuse.IOerror{Code: syscall.EACCES}
 		}
-		return nil
+		return false, nil
 	}
 
-	return n.Open()
+	return false, n.Open()
 }
 
 func (h *SysDevicesVirtualDmiId) Read(

--- a/handler/implementations/sysKernel.go
+++ b/handler/implementations/sysKernel.go
@@ -128,7 +128,7 @@ func (h *SysKernel) Lookup(
 
 func (h *SysKernel) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
 	var resource = n.Name()
 
@@ -138,16 +138,16 @@ func (h *SysKernel) Open(
 	// All emulated resources are currently dummy / empty
 	switch resource {
 	case "config":
-		return nil
+		return false, nil
 	case "debug":
-		return nil
+		return false, nil
 	case "tracing":
-		return nil
+		return false, nil
 	case "security":
-		return nil
+		return false, nil
 	}
 
-	return n.Open()
+	return false, n.Open()
 }
 
 func (h *SysKernel) Read(

--- a/handler/implementations/sysModuleNfconntrackParameters.go
+++ b/handler/implementations/sysModuleNfconntrackParameters.go
@@ -89,9 +89,9 @@ func (h *SysModuleNfconntrackParameters) Lookup(
 
 func (h *SysModuleNfconntrackParameters) Open(
 	n domain.IOnodeIface,
-	req *domain.HandlerRequest) error {
+	req *domain.HandlerRequest) (bool, error) {
 
-	return nil
+	return false, nil
 }
 
 func (h *SysModuleNfconntrackParameters) Read(


### PR DESCRIPTION
Starting with Linux kernel 6.5, sysbox-fs emulation of /proc inside a container is broken, such that when the container reads files under /proc/sys, the files are empty. The reason for the breakage is unclear, but it's either a regression in the kernel or more likely an update of the FUSE protocol at kernel level which the bazil/fuse library used by Sysbox has not been updated to take into account.

The breakage occurs when Sysbox emulates the size of the files under the container's /proc to have size = 0 (as they are in the real /proc). This causes kernel 6.5+ to not read the files for some reason. The work-around is for Sysbox to report a non-zero value for the size of the files under the container's /proc. This PR does this.