### PR TITLE
Ensure sysbox-fs nsenter processes don't leak host mount info inside containers.

### DIFF
--- a/domain/nsenter.go
+++ b/domain/nsenter.go
@@ -31,20 +31,18 @@ const (
 	NStypeMount  NStype = "mnt"
 )
 
+// Security note: nsenter processes spawned by sysbox-fs that enter the pid
+// namespace must also enter the container's mount ns, as otherwise the nsenter
+// process will inherit sysbox-fs host mounts, resulting in a process inside the
+// container that exposes info about those mounts. If needed, the nsenter
+// process can always unshare the mount ns inside the container so that it can
+// perform mounts without affecting the container processes.
+
 var AllNSs = []NStype{
 	string(NStypeUser),
 	string(NStypePid),
 	string(NStypeNet),
 	string(NStypeMount),
-	string(NStypeIpc),
-	string(NStypeCgroup),
-	string(NStypeUts),
-}
-
-var AllNSsButMount = []NStype{
-	string(NStypeUser),
-	string(NStypePid),
-	string(NStypeNet),
 	string(NStypeIpc),
 	string(NStypeCgroup),
 	string(NStypeUts),

--- a/handler/implementations/passThrough_test.go
+++ b/handler/implementations/passThrough_test.go
@@ -134,7 +134,7 @@ func TestPassThrough_Lookup(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type:    domain.LookupRequest,
 						Payload: &domain.LookupPayload{a1.n.Path(), false, true},
@@ -153,7 +153,7 @@ func TestPassThrough_Lookup(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -179,7 +179,7 @@ func TestPassThrough_Lookup(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type:    domain.LookupRequest,
 						Payload: &domain.LookupPayload{a1.n.Path(), false, true},
@@ -197,7 +197,7 @@ func TestPassThrough_Lookup(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -310,7 +310,7 @@ func TestPassThrough_Open(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.OpenFileRequest,
 						Payload: &domain.OpenFilePayload{
@@ -334,7 +334,7 @@ func TestPassThrough_Open(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -359,7 +359,7 @@ func TestPassThrough_Open(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.OpenFileRequest,
 						Payload: &domain.OpenFilePayload{
@@ -383,7 +383,7 @@ func TestPassThrough_Open(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -498,7 +498,7 @@ func TestPassThrough_Read(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.ReadFileRequest,
 						Payload: &domain.ReadFilePayload{
@@ -522,7 +522,7 @@ func TestPassThrough_Read(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -636,7 +636,7 @@ func TestPassThrough_Write(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.WriteFileRequest,
 						Payload: &domain.WriteFilePayload{
@@ -660,7 +660,7 @@ func TestPassThrough_Write(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -691,7 +691,7 @@ func TestPassThrough_Write(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.WriteFileRequest,
 						Payload: &domain.WriteFilePayload{
@@ -715,7 +715,7 @@ func TestPassThrough_Write(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -838,7 +838,7 @@ func TestPassThrough_ReadDirAll(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.ReadDirRequest,
 						Payload: &domain.ReadDirPayload{
@@ -867,7 +867,7 @@ func TestPassThrough_ReadDirAll(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),
@@ -898,7 +898,7 @@ func TestPassThrough_ReadDirAll(t *testing.T) {
 				// Expected nsenter request.
 				nsenterEventReq := &nsenter.NSenterEvent{
 					Pid:       a1.req.Pid,
-					Namespace: &domain.AllNSsButMount,
+					Namespace: &domain.AllNSs,
 					ReqMsg: &domain.NSenterMessage{
 						Type: domain.ReadDirRequest,
 						Payload: &domain.ReadDirPayload{
@@ -920,7 +920,7 @@ func TestPassThrough_ReadDirAll(t *testing.T) {
 				nss.On(
 					"NewEvent",
 					a1.req.Pid,
-					&domain.AllNSsButMount,
+					&domain.AllNSs,
 					uint32(unix.CLONE_NEWNS),
 					nsenterEventReq.ReqMsg,
 					(*domain.NSenterMessage)(nil),

--- a/nsenter/utils.go
+++ b/nsenter/utils.go
@@ -17,21 +17,103 @@
 package nsenter
 
 import (
+	"os"
+	"strings"
+
 	"golang.org/x/sys/unix"
 )
 
-func processPayloadMounts(mountSysfs, mountProcfs bool) error {
-	var flags uintptr = unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV | unix.MS_RELATIME
+type payloadMountsInfo struct {
+	sysfsMountpoint  string
+	procfsMountpoint string
+	cleanup          func()
+}
+
+// This function runs when the sysbox-fs nsenter helper process requests to
+// mount procfs or sysfs.
+//
+// Note that the container process should do so from an unshared mount
+// namespace, such that the mounts are NOT visible inside the container
+// (otherwise container processes will see the nsenter process mounts which are
+// inherited from sysbox-fs mounts, thus leaking host info into the container).
+//
+// Note also that the nsenter process mounts the real procfs and sysfs, not the
+// sysbox-fs emulated ones. That's because the nsenter process is not under
+// seccomp-notify intercepts on mount syscalls as the container processes are.
+func processPayloadMounts(mountSysfs, mountProcfs bool) (*payloadMountsInfo, error) {
+	var (
+		flags            uintptr
+		sysfsMountpoint  string
+		procfsMountpoint string
+		err              error
+	)
+
+	flags = unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV | unix.MS_RELATIME
+
+	// Ideally we want to mount procfs on /proc and sysfs on /sys, inside the
+	// container; and since the mounts are done by the nsenter process in a
+	// dedicated mount-ns, the container processes won't see them. While it's
+	// possible for the nsenter process to mount procfs on top of the container's
+	// /proc, turns out it's not possible to mount sysfs on top of the
+	// container's /sys (the kernel returns a "resource busy" error). Thus, we
+	// mount sysfs on a temporary ephemeral dir inside the container, at
+	// /.sysbox-sysfs-<random-id>. Note that only the nsenter process can see the
+	// mount (because it operates in a dedicated mount-ns). The container
+	// processes will never see the mount, and therefore the
+	// /.sysbox-sysfs-<random-id> dir will always look empty to container
+	// processes.
 
 	if mountSysfs {
-		if err := unix.Mount("sysfs", "/sys", "sysfs", flags, ""); err != nil {
-			return err
+		sysfsMountpoint, err = os.MkdirTemp("/", ".sysbox-sysfs-")
+		if err != nil {
+			return nil, err
+		}
+		if err = unix.Mount("sysfs", sysfsMountpoint, "sysfs", flags, ""); err != nil {
+			os.RemoveAll(sysfsMountpoint)
+			return nil, err
 		}
 	}
+	cleanupSysfs := func() {
+		if sysfsMountpoint != "" {
+			unix.Unmount(sysfsMountpoint, unix.MNT_FORCE)
+			os.RemoveAll(sysfsMountpoint)
+		}
+	}
+
 	if mountProcfs {
-		if err := unix.Mount("proc", "/proc", "proc", flags, ""); err != nil {
-			return err
+		procfsMountpoint = "/proc"
+		if err = unix.Mount("proc", procfsMountpoint, "proc", flags, ""); err != nil {
+			cleanupSysfs()
+			return nil, err
 		}
 	}
-	return nil
+	cleanupProcfs := func() {
+		if procfsMountpoint != "" {
+			unix.Unmount(procfsMountpoint, unix.MNT_FORCE)
+		}
+	}
+
+	cleanup := func() {
+		cleanupSysfs()
+		cleanupProcfs()
+	}
+
+	pmi := &payloadMountsInfo{
+		sysfsMountpoint:  sysfsMountpoint,
+		procfsMountpoint: procfsMountpoint,
+		cleanup:          cleanup,
+	}
+
+	return pmi, nil
+}
+
+func replaceProcfsAndSysfsPaths(path string, pmi *payloadMountsInfo) string {
+
+	if strings.HasPrefix(path, "/sys/") {
+		path = strings.Replace(path, "/sys/", pmi.sysfsMountpoint+"/", 1)
+	} else if strings.HasPrefix(path, "/proc/") {
+		path = strings.Replace(path, "/proc/", pmi.procfsMountpoint+"/", 1)
+	}
+
+	return path
 }


### PR DESCRIPTION
Background:

When a container performs an access to /proc or /sys resources emulated by
sysbox-fs, or when it runs a system call trapped by Sysbox, Sysbox sometimes
dispatches an ephemeral "nsenter" process that enters the container's
namespaces, performs an action within them, and exits.

Problem:

An issue was discovered and reported by a team at Klarna.com, whereby the
nsenter process was exposing host mount info inside the container. Since it's
common for the nsenter process to enter the container's pid namespace, it's PID
and therefore it's mounts, were visible by other processes within the
container. Thus, host mount info was "leaked" inside the container, which is not
ideal (even though it's unlikely the container could do much with it since it's
guarded by it's chroot jail and linux namespaces, particularly the user
namespace).

The underlying problem was that the nsenter process was in some cases not
entering the container's mount namespace, because it wanted to perform
mounts of procfs and sysfs without the container noticing. However, by not
entering the container's mount namespaces, it was carrying with it the
host mounts it inherits from its parent process (sysbox-fs).

Solution:

The solution is for the nsenter process to always enter the container's mount
namespace; this way it let's go of it's parent process mounts and only sees the
container's mounts (i.e., no more host mount leakage in the container). If the
nsenter process needs to do some mounts of it's own, then after having entered
the container's mount namespaces, it will unshare its mount namespace so that it
can perform these mounts without affecting the container. Note that even though
other container processes can see the PID of the ephemeral nsenter process, they
won't be able to access any new mounts done by this process and won't have
permission to enter its mount namespace either.

Special thanks to Gabriele Diener at Klarna.com for reporting this issue.