### PR TITLE
Fix to allow access to /proc/sys/kernel/shm* files inside Sysbox containers.

### DIFF
--- a/domain/handler.go
+++ b/domain/handler.go
@@ -113,6 +113,13 @@ type HandlerIface interface {
 	GetResourceMutex(node IOnodeIface) *sync.Mutex
 }
 
+type PassthroughHandlerIface interface {
+	HandlerIface
+	OpenWithNS(node IOnodeIface, req *HandlerRequest, namespaces []NStype) (bool, error)
+	ReadWithNS(node IOnodeIface, req *HandlerRequest, namespaces []NStype) (int, error)
+	WriteWithNS(node IOnodeIface, req *HandlerRequest, namespaces []NStype) (int, error)
+}
+
 type HandlerServiceIface interface {
 	Setup(
 		hdlrs []HandlerIface,
@@ -131,7 +138,7 @@ type HandlerServiceIface interface {
 
 	// getters/setters
 	HandlersResourcesList() []string
-	GetPassThroughHandler() HandlerIface
+	GetPassThroughHandler() PassthroughHandlerIface
 	StateService() ContainerStateServiceIface
 	SetStateService(css ContainerStateServiceIface)
 	ProcessService() ProcessServiceIface

--- a/handler/handlerDB.go
+++ b/handler/handlerDB.go
@@ -86,7 +86,7 @@ type handlerService struct {
 	hostUuid string
 
 	// Passthrough handler.
-	passThroughHandler domain.HandlerIface
+	passThroughHandler domain.PassthroughHandlerIface
 
 	// Handler i/o errors should be obviated if this flag is enabled (testing
 	// purposes).
@@ -95,7 +95,6 @@ type handlerService struct {
 
 // HandlerService constructor.
 func NewHandlerService() domain.HandlerServiceIface {
-
 	return &handlerService{}
 }
 
@@ -278,7 +277,7 @@ func (hs *handlerService) HandlersResourcesList() []string {
 	return resourcesList
 }
 
-func (hs *handlerService) GetPassThroughHandler() domain.HandlerIface {
+func (hs *handlerService) GetPassThroughHandler() domain.PassthroughHandlerIface {
 	return hs.passThroughHandler
 }
 

--- a/handler/implementations/utils.go
+++ b/handler/implementations/utils.go
@@ -294,18 +294,19 @@ func writeHostFs(
 	return len(data), nil
 }
 
-// writeMaxIntToFs interprets the given data as integers and returns true if new > curr; meant
-// to be used at the 'wrCondition' argument in writeFs()
+// writeMaxIntToFs interprets the given data as 64-bit signed integers and
+// returns true if new > curr; meant to be used at the 'wrCondition' argument in
+// writeFs()
 func writeMaxIntToFs(curr, new []byte) (bool, error) {
 
 	newStr := strings.TrimSpace(string(new))
-	newInt, err := strconv.Atoi(newStr)
+	newInt, err := strconv.ParseInt(newStr, 10, 64)
 	if err != nil {
 		return false, err
 	}
 
 	currStr := strings.TrimSpace(string(curr))
-	currInt, err := strconv.Atoi(currStr)
+	currInt, err := strconv.ParseInt(currStr, 10, 64)
 	if err != nil {
 		return false, err
 	}
@@ -313,18 +314,19 @@ func writeMaxIntToFs(curr, new []byte) (bool, error) {
 	return newInt > currInt, nil
 }
 
-// writeMinIntToFs interprets the given data as integers and returns true if new < curr; meant
-// to be used at the 'wrCondition' argument in writeFs()
+// writeMinIntToFs interprets the given data as 64-bit signed integers and
+// returns true if new < curr; meant to be used at the 'wrCondition' argument in
+// writeFs()
 func writeMinIntToFs(curr, new []byte) (bool, error) {
 
 	newStr := strings.TrimSpace(string(new))
-	newInt, err := strconv.Atoi(newStr)
+	newInt, err := strconv.ParseInt(newStr, 10, 64)
 	if err != nil {
 		return false, err
 	}
 
 	currStr := strings.TrimSpace(string(curr))
-	currInt, err := strconv.Atoi(currStr)
+	currInt, err := strconv.ParseInt(currStr, 10, 64)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Even though the /proc/sys/kernel/shm* files (to control shared memory limits) are
namespaced in the kernel via the IPC namespace, the kernel only allows true root
to write to these files. Therefore, a sysbox container root user is not allowed
to write to these files. For example:

```
$ docker run --runtime=sysbox-runc --rm -it alpine sh
#/ echo 1024 > /proc/sys/kernel/shmmax
error: permission denied
```

To overcome this, improve the sysbox-fs procSysKernel handler to service
accesses to these files without entering the Sysbox container's user-namespace.
This also required corresponding changes to the passthrough handler.