### PR TITLE
Return error for disallowed unmount of sysbox-fs managed mountpoint.

### DIFF
--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -125,9 +125,9 @@ func (u *umountSyscallInfo) process() (*sysResponse, error) {
 		return u.tracer.createContinueResponse(u.reqId), nil
 
 	} else if mip.IsSysboxfsSubmount(u.Target) {
-		logrus.Debugf("Ignoring unmount of sysbox-fs managed submount at %s",
+		logrus.Infof("Rejected unmount of sysbox-fs managed submount at %s",
 			u.Target)
-		return u.tracer.createSuccessResponse(u.reqId), nil
+		return u.tracer.createErrorResponse(u.reqId, syscall.EINVAL), nil
 	}
 
 	// Verify if the umount op is addressing an immutable resource and prevent


### PR DESCRIPTION
Sysbox disallows unmounts of sysbox-fs managed mountpoints that are remounted within the container.

For example, Sysbox emulates the /sys/devices/virtual directory within the container (i.e., it's a sysbox-fs mount). If the container's root directory ("/") is bind mounted recursively at "/new-root", then directory "/new-root/sys/devices/virtual" is also a sysbox-fs mountpoint.

By design Sysbox will disallow umounts of "/new-root/sys/devices/virtual" because for security reasons we don't want the processes inside the container to real "/sys/devices/virtual" directory.

However sysbox-fs had a bug where upon disallowing the unmount, it was not returning an error, but rather returning success but ignoring the unmount.  This confused processes inside the container which think the unmount was done properly yet find that the mountpoint is still there (since the unmount was ignored), causing such processes to spin. See Sysbox issue 808 for an example (https://github.com/nestybox/sysbox/issues/808).

This commit causes sysbox-fs to return an error for the disallowed unmount operation, as well as log it in the sysbox-fs log.