### PR TITLE
Fix left-over .sysbox dirs inside the container.

### DIFF
--- a/nsenter/utils.go
+++ b/nsenter/utils.go
@@ -96,7 +96,7 @@ func processPayloadMounts(mountSysfs, mountProcfs bool) (*payloadMountsInfo, err
 	cleanupSysfs := func(mountpoint string) {
 		if mountpoint != "" {
 			unix.Unmount(mountpoint, unix.MNT_DETACH)
-			if strings.HasPrefix(mountpoint, ".sysbox-sysfs-") {
+			if strings.HasPrefix(mountpoint, "/.sysbox-sysfs-") {
 				os.RemoveAll(mountpoint)
 			}
 		}
@@ -125,6 +125,9 @@ func processPayloadMounts(mountSysfs, mountProcfs bool) (*payloadMountsInfo, err
 	cleanupProcfs := func(mountpoint string) {
 		if mountpoint != "" {
 			unix.Unmount(mountpoint, unix.MNT_DETACH)
+			if strings.HasPrefix(mountpoint, "/.sysbox-procfs-") {
+				os.RemoveAll(mountpoint)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes left-over .sysbox-procfs-* and .sysbox-sysfs-* dirs inside containers. They were being incorrectly left over by sysbox-fs nsenter processes.

Fixes https://github.com/nestybox/sysbox/issues/829.