### PR TITLE
Resolve /proc/thread-self/* in syscall interception code.

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -937,10 +937,14 @@ func TestReplaceProcSelfWithProcPid(t *testing.T) {
 	}
 
 	test := map[testInput]string{
-		{"/proc/self/mem", 10, 100}:         "/proc/10/mem",
-		{"/proc/self/task/123/io", 20, 200}: "/proc/20/task/200/io",
-		{"/proc/123/task/456/mem", 20, 200}: "/proc/123/task/456/mem",
-		{"/some/other/path", 20, 200}:       "/some/other/path",
+		{"/proc/self/mem", 10, 100}:                    "/proc/10/mem",
+		{"/proc/self/some/path", 10, 100}:              "/proc/10/some/path",
+		{"/proc/self/task/123/io", 20, 200}:            "/proc/20/task/200/io",
+		{"/proc/self/task/123/some/path", 20, 200}:     "/proc/20/task/200/some/path",
+		{"/proc/thread-self/mem", 20, 200}:             "/proc/20/task/200/mem",
+		{"/proc/thread-self/some/other/path", 20, 200}: "/proc/20/task/200/some/other/path",
+		{"/proc/123/task/456/mem", 20, 200}:            "/proc/123/task/456/mem",
+		{"/some/other/path", 20, 200}:                  "/some/other/path",
 	}
 
 	for k, v := range test {


### PR DESCRIPTION
When intercepting system calls that use filepaths as arguments, those paths may be regular paths or may be paths under /proc (e.g., "/proc/self/fd/<num>", "/proc/self/task/<tid>/fd/<num>", or "/proc/thread-self/fd/<num>"). Sysbox was dealing properly with the first two but not with the last one (i.e., "/proc/thread-self/*").

This went unnoticed until a recent change in the OCI runc (commit 8e8b136c4923ac33567c4cb775c6c8a17749fd02) where it's now using "/proc/thread-self/<path>" in mount system calls it issues. When that new OCI runc ran inside a Sysbox container, it failed with an error such as:

"error mounting "proc" to rootfs at "/proc": mount src=proc, dst=/proc, dstFd=/proc/thread-self/fd/8, flags=0xe: no such file or directory: unknown."

See https://github.com/nestybox/sysbox/issues/879 for further info.

This commit fixes this by updating Sysbox to deal properly with syscalls that have "/proc/thread-self/*" in their arguments.