### PR TITLE
Fix for issue 854

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -712,9 +712,16 @@ func (p *process) ResolveProcSelf(path string) (string, error) {
 		}
 
 		// path is a symlink, resolve it
-		currPath, err = os.Readlink(currPath)
+		link, err := os.Readlink(currPath)
 		if err != nil {
 			return "", err
+		}
+
+		if filepath.IsAbs(link) {
+			currPath = link
+		} else {
+			// the link is relative, resolve it
+			currPath = filepath.Clean(filepath.Join(filepath.Dir(currPath), link))
 		}
 	}
 

--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -114,11 +114,6 @@ func (u *umountSyscallInfo) process() (*sysResponse, error) {
 			// For sysfs we do something similar to procfs.
 			logrus.Debugf("Processing sysfs unmount: %v", u)
 			return u.processUmount(mip)
-
-		case "overlay":
-			// Handle umounts of overlay fs.
-			logrus.Debugf("Processing overlayfs unmount: %v", u)
-			return u.processUmount(mip)
 		}
 
 		// Not a mount we manage, have the kernel do the unmount.


### PR DESCRIPTION
Delay PathAccess check in umount syscall processing.
    
In the `umount` syscall processing, rather than performing the `PathAccess()` check upfront (to check if the process has the required permissions to access the directory being unmounted), delay it until we know it refers to a sysbox-fs managed mount or an immutable mount.
    
This means that for other mountpoints (i.e., those not managed by sysbox-fs), we let the kernel do the path access check since it's the kernel that processes those mounts anyway.
    
Why this change? because this allow us to work-around a problem where while processing the `umount` syscall, `PathAccess()` unexpectedly fails on a FUSE-backed mount inside the container (see [Sysbox issue #854](https://github.com/nestybox/sysbox/issues/854)). The failure is caused by the FUSE backed mount not showing up properly under `/proc/<pid>/root/<path-to-fuse-mountpoint>` (where `<pid>` is the container's process ID in the Sysbox pid namespace).
    
Turns out that for some reason, for FUSE-backed mountpoints, the kernel only shows the mountpoint under `/proc/<pid>/root/<path-to-fuse-mountpoint>` when it's read from within the user and mount namespaces of the container. Thus it fails when accessed by sysbox-fs directly. This behavior does not reproduce on other mountpoint types, which is why we didn't detect this problem before (e.g., I tried with a tmpfs mount inside the container, and verified that `/proc/<pid>/root/<path-to-tmpfs-mountpoint>` works fine).

So in short, this PR does an "easy" work-around for a problem whose "real" solution would require sysbox-fs to enter the namespaces of the container and perform the PathAccess() check from within.