### PR TITLE
Fix access to /proc/sys/kernel/shm* inside container.

### DIFF
--- a/domain/handler.go
+++ b/domain/handler.go
@@ -151,4 +151,5 @@ type HandlerServiceIface interface {
 	FindUserNsInode(pid uint32) (Inode, error)
 	HostUuid() string
 	FindHostUuid() (string, error)
+	ShmSysctlUserNamespaced() bool
 }

--- a/handler/implementations/procSysKernel.go
+++ b/handler/implementations/procSysKernel.go
@@ -381,13 +381,16 @@ func (h *ProcSysKernel) Open(
 
 	case "printk":
 		return false, nil
+	}
 
-	case "shmall":
-		fallthrough
-	case "shmmax":
-		fallthrough
-	case "shmmni":
-		return h.Service.GetPassThroughHandler().OpenWithNS(n, req, domain.AllNSsButUser)
+	if !h.Service.ShmSysctlUserNamespaced() {
+		if resource == "shmall" ||
+			resource == "shmmax" ||
+			resource == "shmmni" {
+			// If the /proc/sys/kernel/shm* sysctls can't be accessed from within a
+			// user-ns, then don't enter it.
+			return h.Service.GetPassThroughHandler().OpenWithNS(n, req, domain.AllNSsButUser)
+		}
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -436,13 +439,16 @@ func (h *ProcSysKernel) Read(
 
 	case "printk":
 		return readCntrData(h, n, req)
+	}
 
-	case "shmall":
-		fallthrough
-	case "shmmax":
-		fallthrough
-	case "shmmni":
-		return h.Service.GetPassThroughHandler().ReadWithNS(n, req, domain.AllNSsButUser)
+	if !h.Service.ShmSysctlUserNamespaced() {
+		if resource == "shmall" ||
+			resource == "shmmax" ||
+			resource == "shmmni" {
+			// If the /proc/sys/kernel/shm* sysctls can't be accessed from within a
+			// user-ns, then don't enter it.
+			return h.Service.GetPassThroughHandler().ReadWithNS(n, req, domain.AllNSsButUser)
+		}
 	}
 
 	// Refer to generic handler if no node match is found above.
@@ -506,18 +512,16 @@ func (h *ProcSysKernel) Write(
 
 	case "hostname":
 		return writeCntrData(h, n, req, nil)
+	}
 
-	case "shmall":
-		fallthrough
-	case "shmmax":
-		fallthrough
-	case "shmmni":
-		// The kernel only allows true root to write to /proc/sys/kernel/shm*.
-		// Root in the container's user-namespaces is not allowed to modify these
-		// values, even though they are namespaced via the IPC namespace.
-		// Therefore ask the passhthrough handler to enter all namespaces except
-		// the user-ns, as otherwise we get permission denied.
-		return h.Service.GetPassThroughHandler().WriteWithNS(n, req, domain.AllNSsButUser)
+	if !h.Service.ShmSysctlUserNamespaced() {
+		if resource == "shmall" ||
+			resource == "shmmax" ||
+			resource == "shmmni" {
+			// If the /proc/sys/kernel/shm* sysctls can't be accessed from within a
+			// user-ns, then don't enter it.
+			return h.Service.GetPassThroughHandler().WriteWithNS(n, req, domain.AllNSsButUser)
+		}
 	}
 
 	// Refer to generic handler if no node match is found above.


### PR DESCRIPTION
Back in commit 3599e78, we determined that /proc/sys/kernel/shm* sysctls were namespaced by the kernel, however accessing them from within a Sysbox container was not possible because the kernel was only allowing "true root" to write to the sysctls. Since this is clearly a kernel bug, to work-around it the above-referenced commit added a procfs emulation handler that entered all container namespaces except the user-namespace before accessing the /proc/sys/kernel/shm* sysctls. We also added a test to verify the work-around behaved as expected.

However, starting with kernel 6.9 (see upstream commit 50ec499b9a43), access to /proc/sys/kernel/shm* from within a user-ns works (as it should be). However this causes the work-around that we previously added in Sysbox to fail. Users reported this in Sysbox issues 903 and 909.

To make Sysbox work, this commit causes sysbox-fs to check if the host supports writes to /proc/sys/kernel/shm* sysctls from within a user-ns. The check is done when sysbox-fs starts up. If the host kernel supports such access, then Sysbox has nothing to do to enable containers to access those sysctls. If the host kernel does not support such access, then Sysbox applies the work-around we added back in commit 3599e78.