### PR TITLE
sysbox-fs/seccomp: add CIFS/SMB3 mount proxy

### DIFF
--- a/seccomp/mount.go
+++ b/seccomp/mount.go
@@ -75,7 +75,7 @@ func (m *mountSyscallInfo) process() (*sysResponse, error) {
 			return m.processSysMount(mip)
 		case "overlay":
 			return m.processOverlayMount(mip)
-		case "nfs":
+		case "nfs", "cifs", "smb3":
 			return m.processNfsMount(mip)
 		}
 	}
@@ -518,18 +518,18 @@ func (m *mountSyscallInfo) createOverlayMountPayload(
 	return &payload
 }
 
-// Method handles "nfs" mount syscall requests. Sysbox-fs does not manage nfs
+// Method handles "nfs", "cifs", and "smb3" mount syscall requests. Sysbox-fs does not manage nfs
 // mounts per-se, but only "proxies" the nfs mount syscall. It does this in
 // order to enable nfs to be mounted from within a (non init) user-ns.
 func (m *mountSyscallInfo) processNfsMount(
 	mip domain.MountInfoParserIface) (*sysResponse, error) {
 
-	logrus.Debugf("Processing new nfs mount: %v", m)
+	logrus.Debugf("Processing new %s mount: %v", m.FsType, m)
 
 	// Create instruction's payload.
 	payload := m.createNfsMountPayload(mip)
 	if payload == nil {
-		return nil, fmt.Errorf("Could not construct nfsMount payload")
+		return nil, fmt.Errorf("Could not construct %s mount payload", m.FsType)
 	}
 
 	// Create nsenter-event envelope; enter as true root to have required privileges.


### PR DESCRIPTION
Extend processNfsMount to also handle "cifs" and "smb3" filesystem types. The existing NFS proxy already does exactly what CIFS needs: re-issue mount(2) via nsenter as host root (AllNSsButUser).

- mount.go: add "cifs", "smb3" to the processNfsMount dispatch case; update function comment; use m.FsType in the debug log

Tested: ubuntu:24.04, cifs-utils 7.0, guest share, vers=3.1.1

Fixes [#856](https://github.com/nestybox/sysbox/issues/856)