### PR TITLE
seccomp/state: guard remaining unguarded cntr.InitProc() call sites

### DIFF
--- a/seccomp/mount.go
+++ b/seccomp/mount.go
@@ -646,13 +646,17 @@ func (m *mountSyscallInfo) remountAllowed(
 	if err != nil {
 		return false, m.tracer.createErrorResponse(m.reqId, syscall.EINVAL)
 	}
-	initProcMountNs, err := m.cntr.InitProc().MountNsInode()
+	initProc := m.cntr.InitProc()
+	if initProc == nil {
+		return false, m.tracer.createErrorResponse(m.reqId, syscall.EINVAL)
+	}
+	initProcMountNs, err := initProc.MountNsInode()
 	if err != nil {
 		return false, m.tracer.createErrorResponse(m.reqId, syscall.EINVAL)
 	}
 
 	// Obtain the sys-container's root-path inode.
-	syscntrRootInode := m.cntr.InitProc().RootInode()
+	syscntrRootInode := initProc.RootInode()
 
 	// If process' mount-ns matches the sys-container's one, then we can simply
 	// rely on the target's mountID to discern an immutable target from a

--- a/seccomp/umount.go
+++ b/seccomp/umount.go
@@ -184,13 +184,17 @@ func (u *umountSyscallInfo) umountAllowed(
 	if err != nil {
 		return false, u.tracer.createErrorResponse(u.reqId, syscall.EINVAL)
 	}
-	initProcMountNs, err := u.cntr.InitProc().MountNsInode()
+	initProc := u.cntr.InitProc()
+	if initProc == nil {
+		return false, u.tracer.createErrorResponse(u.reqId, syscall.EINVAL)
+	}
+	initProcMountNs, err := initProc.MountNsInode()
 	if err != nil {
 		return false, u.tracer.createErrorResponse(u.reqId, syscall.EINVAL)
 	}
 
 	// Obtain the sys-container's root-path inode.
-	syscntrRootInode := u.cntr.InitProc().RootInode()
+	syscntrRootInode := initProc.RootInode()
 
 	// If process' mount-ns matches the sys-container's one, then we can simply
 	// rely on the target's mountID to discern an immutable target from a

--- a/state/containerDB.go
+++ b/state/containerDB.go
@@ -393,7 +393,11 @@ func (css *containerStateService) trackNetns(cntr *container, netns string) ([]*
 				return nil, fmt.Errorf("Error getting netns inode: %v", err)
 			}
 		} else {
-			netnsInode, err = cntr.InitProc().NetNsInode()
+			initProc := cntr.InitProc()
+			if initProc == nil {
+				return nil, fmt.Errorf("Container %s has no init process registered yet", cntr.id)
+			}
+			netnsInode, err = initProc.NetNsInode()
 			if err != nil {
 				return nil, fmt.Errorf("Error getting netns inode: %v", err)
 			}


### PR DESCRIPTION
Follow-up to #120. That PR fixed a nil-pointer panic in `ProcessNsMatch()`
caused by `cntr.InitProc()` returning nil when a request races ahead of
container registration (see #1003), but only guarded the two call sites
hit by that specific repro.

This guards the remaining 5 unguarded call sites of `cntr.InitProc()`,
which are exposed to the same race:

- `state/containerDB.go` (`trackNetns`) — returns an error instead of
  panicking.
- `seccomp/umount.go` (`umountAllowed`) — falls back to the existing
  `createErrorResponse(EINVAL)` path, consistent with the function's
  other error handling ("let the kernel deal with it").
- `seccomp/mount.go` (`remountAllowed`) — same pattern.